### PR TITLE
Service Node Deregister Part 1

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -157,6 +157,14 @@ namespace cryptonote
   {
 
   public:
+    enum version
+    {
+      version_0 = 0,
+      version_1,
+      version_2,
+      version_3_deregister_tx,
+    };
+
     // tx information
     size_t   version;
     uint64_t unlock_time;  //number of block (or time), used as a limitation like: spend this tx not early then block/time

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -399,22 +399,27 @@ namespace cryptonote
     return get_tx_pub_key_from_extra(tx.extra, pk_index);
   }
   //---------------------------------------------------------------
-  bool add_tx_pub_key_to_extra(transaction& tx, const crypto::public_key& tx_pub_key)
+  static void add_data_to_tx_extra(std::vector<uint8_t>& tx_extra, char const *data, size_t data_size, uint8_t tag)
   {
-    return add_tx_pub_key_to_extra(tx.extra, tx_pub_key);
+    size_t pos = tx_extra.size();
+    tx_extra.resize(tx_extra.size() + sizeof(tag) + data_size);
+    tx_extra[pos++] = tag;
+    std::memcpy(&tx_extra[pos], data, data_size);
   }
   //---------------------------------------------------------------
-  bool add_tx_pub_key_to_extra(transaction_prefix& tx, const crypto::public_key& tx_pub_key)
+  void add_tx_pub_key_to_extra(transaction& tx, const crypto::public_key& tx_pub_key)
   {
-    return add_tx_pub_key_to_extra(tx.extra, tx_pub_key);
+    add_tx_pub_key_to_extra(tx.extra, tx_pub_key);
   }
   //---------------------------------------------------------------
-  bool add_tx_pub_key_to_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& tx_pub_key)
+  void add_tx_pub_key_to_extra(transaction_prefix& tx, const crypto::public_key& tx_pub_key)
   {
-    tx_extra.resize(tx_extra.size() + 1 + sizeof(crypto::public_key));
-    tx_extra[tx_extra.size() - 1 - sizeof(crypto::public_key)] = TX_EXTRA_TAG_PUBKEY;
-    *reinterpret_cast<crypto::public_key*>(&tx_extra[tx_extra.size() - sizeof(crypto::public_key)]) = tx_pub_key;
-    return true;
+    add_tx_pub_key_to_extra(tx.extra, tx_pub_key);
+  }
+  //---------------------------------------------------------------
+  void add_tx_pub_key_to_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& tx_pub_key)
+  {
+    add_data_to_tx_extra(tx_extra, reinterpret_cast<const char *>(&tx_pub_key), sizeof(tx_pub_key), TX_EXTRA_TAG_PUBKEY);
   }
   //---------------------------------------------------------------
   std::vector<crypto::public_key> get_additional_tx_pub_keys_from_extra(const std::vector<uint8_t>& tx_extra)
@@ -465,6 +470,42 @@ namespace cryptonote
     ++start_pos;
     memcpy(&tx_extra[start_pos], extra_nonce.data(), extra_nonce.size());
     return true;
+  }
+  //---------------------------------------------------------------
+  void add_service_node_deregister_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister& deregistration)
+  {
+    tx_extra_field field = tx_extra_service_node_deregister{deregistration.block_height, deregistration.service_node_index, deregistration.votes};
+
+    std::ostringstream oss;
+    binary_archive<true> ar(oss);
+    bool r = ::do_serialize(ar, field);
+    CHECK_AND_ASSERT_MES_NO_RET(r, "failed to serialize tx extra service node deregister");
+
+    std::string tx_extra_str = oss.str();
+    size_t pos = tx_extra.size();
+    tx_extra.resize(tx_extra.size() + tx_extra_str.size());
+    memcpy(&tx_extra[pos], tx_extra_str.data(), tx_extra_str.size());
+  }
+  //---------------------------------------------------------------
+  void add_service_node_register_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_register& registration)
+  {
+    add_data_to_tx_extra(tx_extra, reinterpret_cast<const char*>(&registration), sizeof(registration), TX_EXTRA_TAG_SERVICE_NODE_REGISTER);
+  }
+  //---------------------------------------------------------------
+  bool get_service_node_register_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_register &registration)
+  {
+    std::vector<tx_extra_field> tx_extra_fields;
+    parse_tx_extra(tx_extra, tx_extra_fields);
+    bool result = find_tx_extra_field_by_type(tx_extra_fields, registration);
+    return result;
+  }
+  //---------------------------------------------------------------
+  bool get_service_node_deregister_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_deregister &deregistration)
+  {
+    std::vector<tx_extra_field> tx_extra_fields;
+    parse_tx_extra(tx_extra, tx_extra_fields);
+    bool result = find_tx_extra_field_by_type(tx_extra_fields, deregistration);
+    return result;
   }
   //---------------------------------------------------------------
   bool remove_field_from_tx_extra(std::vector<uint8_t>& tx_extra, const std::type_info &type)

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -67,9 +67,13 @@ namespace cryptonote
   crypto::public_key get_tx_pub_key_from_extra(const std::vector<uint8_t>& tx_extra, size_t pk_index = 0);
   crypto::public_key get_tx_pub_key_from_extra(const transaction_prefix& tx, size_t pk_index = 0);
   crypto::public_key get_tx_pub_key_from_extra(const transaction& tx, size_t pk_index = 0);
-  bool add_tx_pub_key_to_extra(transaction& tx, const crypto::public_key& tx_pub_key);
-  bool add_tx_pub_key_to_extra(transaction_prefix& tx, const crypto::public_key& tx_pub_key);
-  bool add_tx_pub_key_to_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& tx_pub_key);
+  void add_tx_pub_key_to_extra(transaction& tx, const crypto::public_key& tx_pub_key);
+  void add_tx_pub_key_to_extra(transaction_prefix& tx, const crypto::public_key& tx_pub_key);
+  void add_tx_pub_key_to_extra(std::vector<uint8_t>& tx_extra, const crypto::public_key& tx_pub_key);
+  void add_service_node_deregister_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_deregister& deregistration);
+  void add_service_node_register_to_tx_extra(std::vector<uint8_t>& tx_extra, const tx_extra_service_node_register& registration);
+  bool get_service_node_register_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_register& registration);
+  bool get_service_node_deregister_from_tx_extra(const std::vector<uint8_t>& tx_extra, tx_extra_service_node_deregister& deregistration);
   std::vector<crypto::public_key> get_additional_tx_pub_keys_from_extra(const std::vector<uint8_t>& tx_extra);
   std::vector<crypto::public_key> get_additional_tx_pub_keys_from_extra(const transaction_prefix& tx);
   bool add_additional_tx_pub_keys_to_extra(std::vector<uint8_t>& tx_extra, const std::vector<crypto::public_key>& additional_pub_keys);

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -31,18 +31,20 @@
 #pragma once
 
 
-#define TX_EXTRA_PADDING_MAX_COUNT          255
-#define TX_EXTRA_NONCE_MAX_COUNT            255
+#define TX_EXTRA_PADDING_MAX_COUNT           255
+#define TX_EXTRA_NONCE_MAX_COUNT             255
 
-#define TX_EXTRA_TAG_PADDING                0x00
-#define TX_EXTRA_TAG_PUBKEY                 0x01
-#define TX_EXTRA_NONCE                      0x02
-#define TX_EXTRA_MERGE_MINING_TAG           0x03
-#define TX_EXTRA_TAG_ADDITIONAL_PUBKEYS     0x04
-#define TX_EXTRA_MYSTERIOUS_MINERGATE_TAG   0xDE
+#define TX_EXTRA_TAG_PADDING                 0x00
+#define TX_EXTRA_TAG_PUBKEY                  0x01
+#define TX_EXTRA_NONCE                       0x02
+#define TX_EXTRA_MERGE_MINING_TAG            0x03
+#define TX_EXTRA_TAG_ADDITIONAL_PUBKEYS      0x04
+#define TX_EXTRA_TAG_SERVICE_NODE_REGISTER   0x70
+#define TX_EXTRA_TAG_SERVICE_NODE_DEREGISTER 0x71
+#define TX_EXTRA_MYSTERIOUS_MINERGATE_TAG    0xDE
 
-#define TX_EXTRA_NONCE_PAYMENT_ID           0x00
-#define TX_EXTRA_NONCE_ENCRYPTED_PAYMENT_ID 0x01
+#define TX_EXTRA_NONCE_PAYMENT_ID            0x00
+#define TX_EXTRA_NONCE_ENCRYPTED_PAYMENT_ID  0x01
 
 namespace cryptonote
 {
@@ -179,16 +181,61 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
+  struct tx_extra_service_node_register
+  {
+    crypto::secret_key secret_view_key;
+    crypto::public_key public_spend_key;
+
+    BEGIN_SERIALIZE()
+      FIELD(secret_view_key)
+      FIELD(public_spend_key)
+    END_SERIALIZE()
+  };
+
+  struct tx_extra_service_node_deregister
+  {
+    // TODO: We don't use crypto::signatures because template overrides on serialization for sigs
+    // don't encode size. So the receiving end must be able to anticipate how many signatures
+    // there are and preallocate. This is possibly doable when we finalize quorum sizes
+    struct signature_pod { char data[sizeof(crypto::signature)]; };
+    struct vote
+    {
+      signature_pod signature;
+      uint32_t      voters_quorum_index;
+    };
+
+    uint64_t          block_height;
+    uint32_t          service_node_index;
+    std::vector<vote> votes;
+
+    BEGIN_SERIALIZE()
+      FIELD(block_height)
+      FIELD(service_node_index)
+      FIELD(votes)
+    END_SERIALIZE()
+  };
+
   // tx_extra_field format, except tx_extra_padding and tx_extra_pub_key:
   //   varint tag;
   //   varint size;
   //   varint data[];
-  typedef boost::variant<tx_extra_padding, tx_extra_pub_key, tx_extra_nonce, tx_extra_merge_mining_tag, tx_extra_additional_pub_keys, tx_extra_mysterious_minergate> tx_extra_field;
+  typedef boost::variant<tx_extra_padding,
+                         tx_extra_pub_key,
+                         tx_extra_nonce,
+                         tx_extra_merge_mining_tag,
+                         tx_extra_additional_pub_keys,
+                         tx_extra_mysterious_minergate,
+                         tx_extra_service_node_register,
+                         tx_extra_service_node_deregister> tx_extra_field;
 }
 
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_padding, TX_EXTRA_TAG_PADDING);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_pub_key, TX_EXTRA_TAG_PUBKEY);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_nonce, TX_EXTRA_NONCE);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_merge_mining_tag, TX_EXTRA_MERGE_MINING_TAG);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_additional_pub_keys, TX_EXTRA_TAG_ADDITIONAL_PUBKEYS);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_mysterious_minergate, TX_EXTRA_MYSTERIOUS_MINERGATE_TAG);
+BLOB_SERIALIZER(cryptonote::tx_extra_service_node_deregister::vote);
+
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_padding,                 TX_EXTRA_TAG_PADDING);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_pub_key,                 TX_EXTRA_TAG_PUBKEY);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_nonce,                   TX_EXTRA_NONCE);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_merge_mining_tag,        TX_EXTRA_MERGE_MINING_TAG);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_additional_pub_keys,     TX_EXTRA_TAG_ADDITIONAL_PUBKEYS);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_mysterious_minergate,    TX_EXTRA_MYSTERIOUS_MINERGATE_TAG);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_register,   TX_EXTRA_TAG_SERVICE_NODE_REGISTER);
+VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_deregister, TX_EXTRA_TAG_SERVICE_NODE_DEREGISTER);

--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -34,6 +34,17 @@ namespace cryptonote
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
+  struct vote_verification_context
+  {
+    bool m_verification_failed;
+    bool m_invalid_block_height;
+    bool m_voters_quorum_index_out_of_bounds;
+    bool m_service_node_index_out_of_bounds;
+    bool m_signature_not_valid;
+    bool m_added_to_pool;
+    bool m_full_tx_deregister_made;
+  };
+
   struct tx_verification_context
   {
     bool m_should_be_relayed;
@@ -48,6 +59,8 @@ namespace cryptonote
     bool m_overspend;
     bool m_fee_too_low;
     bool m_not_rct;
+
+    vote_verification_context m_vote_ctx;
   };
 
   struct block_verification_context

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -41,7 +41,7 @@
 #define CRYPTONOTE_MAX_TX_SIZE                          1000000000
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
 #define CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW            30
-#define CURRENT_TRANSACTION_VERSION                     2
+#define CURRENT_TRANSACTION_VERSION                     3
 #define CURRENT_BLOCK_MAJOR_VERSION                     6
 #define CURRENT_BLOCK_MINOR_VERSION                     6
 #define CURRENT_BLOCK_MAJOR_VERSION_TESTNET             7

--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -30,6 +30,7 @@
 set(cryptonote_core_sources
   blockchain.cpp
   cryptonote_core.cpp
+  service_node_deregister.cpp
   tx_pool.cpp
   cryptonote_tx_utils.cpp)
 
@@ -39,6 +40,7 @@ set(cryptonote_core_private_headers
   blockchain_storage_boost_serialization.h
   blockchain.h
   cryptonote_core.h
+  service_node_deregister.h
   tx_pool.h
   cryptonote_tx_utils.h)
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -35,8 +35,9 @@
 #include "string_tools.h"
 using namespace epee;
 
-#include <random>
 #include <unordered_set>
+#include <random>
+
 #include "cryptonote_core.h"
 #include "common/command_line.h"
 #include "common/util.h"
@@ -632,11 +633,12 @@ namespace cryptonote
     }
     bad_semantics_txes_lock.unlock();
 
-    uint8_t version = m_blockchain_storage.get_current_hard_fork_version();
-    const size_t max_tx_version = version == 1 ? 1 : 2;
+    int version = m_blockchain_storage.get_current_hard_fork_version();
+    unsigned int max_tx_version = version == 1 ? 1 : version < 8 ? 2 : 3;
+
     if (tx.version == 0 || tx.version > max_tx_version)
     {
-      // v2 is the latest one we know
+      // v3 is the latest one we know
       tvc.m_verifivation_failed = true;
       return false;
     }
@@ -770,16 +772,9 @@ namespace cryptonote
     st_inf.top_block_id_str = epee::string_tools::pod_to_hex(m_blockchain_storage.get_tail_id());
     return true;
   }
-
   //-----------------------------------------------------------------------------------------------
   bool core::check_tx_semantic(const transaction& tx, bool keeped_by_block) const
   {
-    if(!tx.vin.size())
-    {
-      MERROR_VER("tx with empty inputs, rejected for tx id= " << get_transaction_hash(tx));
-      return false;
-    }
-
     if(!check_inputs_types_supported(tx))
     {
       MERROR_VER("unsupported input types for tx id= " << get_transaction_hash(tx));
@@ -791,14 +786,6 @@ namespace cryptonote
       MERROR_VER("tx with invalid outputs, rejected for tx id= " << get_transaction_hash(tx));
       return false;
     }
-    if (tx.version > 1)
-    {
-      if (tx.rct_signatures.outPk.size() != tx.vout.size())
-      {
-        MERROR_VER("tx with mismatched vout/outPk count, rejected for tx id= " << get_transaction_hash(tx));
-        return false;
-      }
-    }
 
     if(!check_money_overflow(tx))
     {
@@ -806,27 +793,12 @@ namespace cryptonote
       return false;
     }
 
-    if (tx.version == 1)
-    {
-      uint64_t amount_in = 0;
-      get_inputs_money_amount(tx, amount_in);
-      uint64_t amount_out = get_outs_money_amount(tx);
-
-      if(amount_in <= amount_out)
-      {
-        MERROR_VER("tx with wrong amounts: ins " << amount_in << ", outs " << amount_out << ", rejected for tx id= " << get_transaction_hash(tx));
-        return false;
-      }
-    }
-    // for version > 1, ringct signatures check verifies amounts match
-
     if(!keeped_by_block && get_object_blobsize(tx) >= m_blockchain_storage.get_current_cumulative_blocksize_limit() - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE)
     {
       MERROR_VER("tx is too large " << get_object_blobsize(tx) << ", expected not bigger than " << m_blockchain_storage.get_current_cumulative_blocksize_limit() - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE);
       return false;
     }
 
-    //check if tx use different key images
     if(!check_tx_inputs_keyimages_diff(tx))
     {
       MERROR_VER("tx uses a single key image more than once");
@@ -845,33 +817,99 @@ namespace cryptonote
       return false;
     }
 
-    if (tx.version >= 2)
+    if (tx.version == transaction::version_1)
     {
-      const rct::rctSig &rv = tx.rct_signatures;
-      switch (rv.type) {
-        case rct::RCTTypeNull:
-          // coinbase should not come here, so we reject for all other types
-          MERROR_VER("Unexpected Null rctSig type");
+      uint64_t amount_in = 0;
+      get_inputs_money_amount(tx, amount_in);
+      uint64_t amount_out = get_outs_money_amount(tx);
+
+      if(amount_in <= amount_out)
+      {
+        MERROR_VER("tx with wrong amounts: ins " << amount_in << ", outs " << amount_out << ", rejected for tx id= " << get_transaction_hash(tx));
+        return false;
+      }
+    }
+
+    if(tx.version <= transaction::version_2 && !tx.vin.size())
+    {
+      MERROR_VER("tx with empty inputs, rejected for tx id= " << get_transaction_hash(tx));
+      return false;
+    }
+
+    if (tx.version >= transaction::version_2) // for version >= 2, ringct signatures check verifies amounts match
+    {
+      if (tx.rct_signatures.outPk.size() != tx.vout.size())
+      {
+        MERROR_VER("tx with mismatched vout/outPk count, rejected for tx id= " << get_transaction_hash(tx));
+        return false;
+      }
+
+      if (tx.version == transaction::version_2)
+      {
+        const rct::rctSig &rv = tx.rct_signatures;
+        switch (rv.type) {
+          case rct::RCTTypeNull:
+            // coinbase should not come here, so we reject for all other types
+            MERROR_VER("Unexpected Null rctSig type");
+            return false;
+          case rct::RCTTypeSimple:
+          case rct::RCTTypeSimpleBulletproof:
+            if (!rct::verRctSimple(rv, true))
+            {
+              MERROR_VER("rct signature semantics check failed");
+              return false;
+            }
+            break;
+          case rct::RCTTypeFull:
+          case rct::RCTTypeFullBulletproof:
+            if (!rct::verRct(rv, true))
+            {
+              MERROR_VER("rct signature semantics check failed");
+              return false;
+            }
+            break;
+          default:
+            MERROR_VER("Unknown rct type: " << rv.type);
+            return false;
+        }
+      }
+      else if (tx.version == transaction::version_3_deregister_tx)
+      {
+        // TODO(doyle): Version should only be valid from the hardfork height
+        tx_extra_service_node_deregister deregister;
+        if (!get_service_node_deregister_from_tx_extra(tx.extra, deregister))
+        {
+          MERROR_VER("TX version partial_deregister_tx or deregister_tx did not contain deregister data");
           return false;
-        case rct::RCTTypeSimple:
-        case rct::RCTTypeSimpleBulletproof:
-          if (!rct::verRctSimple(rv, true))
+        }
+
+        // Check service node to deregister is valid
+        {
+          auto xx__is_service_node_registered = ([](uint64_t block_height, uint32_t service_node_index) -> bool {
+            // Check service_node_index is in list bounds
+            // MERROR_VER("TX version deregister_tx specifies invalid service node index: " << deregister.service_node_index << ", value must be between [0, " << quorum.size() << "]");
+            return true;
+          });
+
+          if (!xx__is_service_node_registered(deregister.block_height, deregister.service_node_index))
           {
-            MERROR_VER("rct signature semantics check failed");
+            MERROR_VER("TX version 3 deregister_tx trying to deregister a non-active node");
             return false;
           }
-          break;
-        case rct::RCTTypeFull:
-        case rct::RCTTypeFullBulletproof:
-          if (!rct::verRct(rv, true))
-          {
-            MERROR_VER("rct signature semantics check failed");
-            return false;
-          }
-          break;
-        default:
-          MERROR_VER("Unknown rct type: " << rv.type);
+        }
+
+        uint32_t quorum_size;
+        if (!get_quorum_list_size_for_height(deregister.block_height, quorum_size))
+        {
+          MERROR_VER("TX version 3 deregister_tx could not get quorum for height: " << deregister.block_height);
           return false;
+        }
+
+        if (deregister.votes.size() != quorum_size)
+        {
+          MERROR_VER("TX version 3 deregister_tx requires the number of voters to match: " << deregister.votes.size() << ", which does not match quorum size: " << quorum_size);
+          return false;
+        }
       }
     }
 
@@ -997,6 +1035,30 @@ namespace cryptonote
     if (keeped_by_block)
       get_blockchain_storage().on_new_tx_from_block(tx);
 
+    if (tx.version == transaction::version_3_deregister_tx)
+    {
+      tx_extra_service_node_deregister deregister;
+      if (!get_service_node_deregister_from_tx_extra(tx.extra, deregister))
+      {
+        LOG_PRINT_L1("TX version deregister_tx did not contain deregister data");
+        return false;
+      }
+
+      std::vector<crypto::public_key> quorum;
+      if (!get_quorum_list_for_height(deregister.block_height, quorum))
+      {
+        LOG_PRINT_L1("TX version 3 deregister_tx could not get quorum for height: " << deregister.block_height);
+        return false;
+      }
+
+      if (!loki::service_node_deregister::verify(deregister, tvc.m_vote_ctx, quorum))
+      {
+        tvc.m_verifivation_failed = true;
+        LOG_PRINT_L1("tx " << tx_hash << ": version 3 deregister_tx signed votes do not validate with the spend keys in the quorum.");
+        return false;
+      }
+    }
+
     if(m_mempool.have_tx(tx_hash))
     {
       LOG_PRINT_L2("tx " << tx_hash << "already have transaction in tx_pool");
@@ -1042,6 +1104,7 @@ namespace cryptonote
       LOG_ERROR("Failed to parse relayed transaction");
       return;
     }
+
     txs.push_back(std::make_pair(tx_hash, std::move(tx_blob)));
     m_mempool.set_relayed(txs);
   }
@@ -1218,8 +1281,12 @@ namespace cryptonote
       return false;
     }
     add_new_block(b, bvc);
-    if(update_miner_blocktemplate && bvc.m_added_to_main_chain)
-       update_miner_block_template();
+
+    if (bvc.m_added_to_main_chain)
+    {
+      if(update_miner_blocktemplate)
+         update_miner_block_template();
+    }
     return true;
 
     CATCH_ENTRY_L0("core::handle_incoming_block()", false);
@@ -1564,58 +1631,14 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   static std::vector<crypto::public_key> xx__get_service_nodes_pub_keys_for_height(uint64_t height)
   {
+      loki::xx__service_node::init();
+
       (void)height; // TODO(doyle): Mock function needs to be implemented
-
       std::vector<crypto::public_key> result;
-      const char *XX__PUB_KEYS[] =
+      result.resize(loki::xx__service_node::public_spend_keys.size());
+      for (size_t i = 0; i < result.size(); i++)
       {
-        "cab4ae6148233461074c6bc4c72b8a53ee91d9cfbda5813c3422a3e2897b21e3",
-        "bfae23724257762880ec334b7f83cdda345ff677c34ef141e8ea5cbbe0f61f33",
-        "04932a89171e0a33e3a079e5c61a7454a5bff9fd467ff81cbc18a5ee5ff37bab",
-        "ea505c9ccf83d73654268562487a077423cde586fe5799113e93a8a0b46e9fe5",
-        "4931ddac1a7981f0dd7259bee59281cf540ba6a9ef59a10ef9fe504214ff1f11",
-        "fa0fe218380fa8cc642fad13855789273f9283512dab99010374122c2df92dca",
-        "f6b29bb886e2cf64de7b0887c84d821e96ec56f6e28903f4faa6fecf18b445dd",
-        "7123ae098051a459cf6fc2fdeccad6210136f6e55f8218439864a53501498dc6",
-        "b4aa98188bd958ad7dd10eb19b091ac25647c3b28255b6a02633f57ebf633c9f",
-        "1e4c7a3e7e7dec98e9b5da2ba8d8ea013cb71115a22e926ba060dd8ca9084004",
-        "23f2052a043c17f1e93558ff5fcf1a183c4139384c7d115b32a98d55081dc996",
-        "742db561f88c64e696cec912b8ad4faea78aac871d3d340b664ec63463664113",
-        "28630fa9cc33c0b8a518894becce01b8f0b4eb9f234e2780404dc751ae9d1d99",
-        "ccacea809b1dbe1dc5021281662490b55db41d86dea0715b6b1322a7c344d641",
-        "cd3beb0621b26f0b16cda9c759601997cc054c3e673fa9d91dd1ceb1542a2eec",
-        "40b8be419aff1126a31a2cbb6702aced9960c075919dc2fe44efabdda973a7d1",
-        "42237ef07f9f7570d31dd19fa1141b8ec0b23f9c976a744381452c0d2ea24b98",
-        "0a583ae027590cf6f21a76d6fb7b582d904cd3661fa59a00b1d8bf780e0b8748",
-        "8a60f7a39c88dc8b425a72988d577ec0f198bcecc31162c12b8f696cce441622",
-        "160dc084804efa96129dcc846ea9aeb793e5b208dc947587f2aa5dda4634a877",
-        "cb92e9e8ce31522eeb731b9d069ca4fb327df0f5c1df81c32e45cad5cffdc0f0",
-        "ac7e0e825120d28575182c86e36c6f05666192f573e032f036871969009fa1c7",
-        "89555379367ec70306a00b0460b468c0973987ed6c8084ddac3cf51c505280cd",
-        "7dc31ac32a88bce95808b07cfa27eaad30ebc319c64719a8b63ceacd0542060e",
-        "96bbc02ce1cb673cec7dc649e6ff111d116fcb1660a06a39d09755fd3ba8e133",
-        "7b10fa062ae91169166a32d29e585695cf9204375484252eda89d76ddeb5b163",
-        "65e318c3dac1013de3cdc47e097deca020fe18f12b4c496f7f63935bc99bc2ea",
-        "b34dc0a57f68f1049733e0f610f29ef70f72e5cc237edfc7844cc7b06645066a",
-        "2dd94991268ee71b2356e8d748477a29ddf1aef8a9c329a0279753c599f38c23",
-        "ab3a704dd71dacd1361155e668253ae70bca58cf790141c4174f47403696ffb3",
-        "ceb1256e951a434d2a274be8d33a4773f797207121f774897c43ba258c1f7026",
-        "8502b21a22da7494130f689b58b91fcd48a17071c5554b6c9ec11863caf2e179",
-        "bb25528e6278ddfc0fd91752b9d73d98f01acef361783528b0e6d6d7116c5261",
-        "f7d7c629a96063ed85e2126029e9406b176a45b4876eb22d979ce32eed5ac5d1",
-        "2e7c51924bf910b4fe5ed9d89a9bfe40222fe91cb70dc660bc2e21a8318241e7",
-      };
-
-      size_t const size = sizeof(XX__PUB_KEYS) / sizeof(XX__PUB_KEYS[0]);
-      result.reserve(size);
-
-      {
-        for (size_t i = 0; i < size; i++)
-        {
-          crypto::public_key key;
-          epee::string_tools::hex_to_pod(XX__PUB_KEYS[i], key);
-          result.push_back(key);
-        }
+        result[i] = loki::xx__service_node::public_spend_keys[i];
       }
 
       return result;
@@ -1669,6 +1692,38 @@ namespace cryptonote
       quorum[i] = pub_keys[pub_keys_indexes[i]];
 
     return true;
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::add_deregister_vote(const loki::service_node_deregister::vote& vote, vote_verification_context &vvc)
+  {
+    std::vector<crypto::public_key> quorum;
+    if (!get_quorum_list_for_height(vote.block_height, quorum))
+    {
+      vvc.m_verification_failed  = true;
+      vvc.m_invalid_block_height = true;
+      LOG_ERROR("Could not get quorum for height: " << vote.block_height);
+      return false;
+    }
+
+    cryptonote::transaction deregister_tx;
+    bool result = m_deregister_vote_pool.add_vote(vote, vvc, quorum, deregister_tx);
+    if (result && vvc.m_full_tx_deregister_made)
+    {
+      tx_verification_context tvc;
+      blobdata const tx_blob = tx_to_blob(deregister_tx);
+
+      handle_incoming_tx(tx_blob, tvc, false /*keeped_by_block*/, false /*relayed*/, false /*do_not_relay*/);
+      if (!tvc.m_verifivation_failed)
+      {
+        // TODO(doyle): logging
+      }
+      else
+      {
+        printf("Full deregister tx submitted for block height (%zu) snode (%d)\n", vote.block_height, vote.service_node_index);
+      }
+    }
+
+    return result;
   }
   //-----------------------------------------------------------------------------------------------
   std::time_t core::get_start_time() const

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1109,6 +1109,24 @@ namespace cryptonote
     m_mempool.set_relayed(txs);
   }
   //-----------------------------------------------------------------------------------------------
+  void core::set_deregister_vote_relayed(const std::vector<loki::service_node_deregister::vote>& votes)
+  {
+    m_deregister_vote_pool.set_relayed(votes);
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::relay_deregister_vote()
+  {
+    NOTIFY_NEW_DEREGISTER_VOTE::request req;
+    req.votes = m_deregister_vote_pool.get_relayable_votes();
+    if (!req.votes.empty())
+    {
+      cryptonote_connection_context fake_context = AUTO_VAL_INIT(fake_context);
+      get_protocol()->relay_deregister_vote(req, fake_context);
+    }
+
+    return true;
+  }
+  //-----------------------------------------------------------------------------------------------
   bool core::get_block_template(block& b, const account_public_address& adr, difficulty_type& diffic, uint64_t& height, uint64_t& expected_reward, const blobdata& ex_nonce)
   {
     return m_blockchain_storage.create_block_template(b, adr, diffic, height, expected_reward, ex_nonce);
@@ -1284,6 +1302,8 @@ namespace cryptonote
 
     if (bvc.m_added_to_main_chain)
     {
+      m_deregister_vote_pool.remove_expired_votes(get_current_blockchain_height());
+
       if(update_miner_blocktemplate)
          update_miner_block_template();
     }
@@ -1426,6 +1446,7 @@ namespace cryptonote
 
     m_fork_moaner.do_call(boost::bind(&core::check_fork_time, this));
     m_txpool_auto_relayer.do_call(boost::bind(&core::relay_txpool_transactions, this));
+    m_deregisters_auto_relayer.do_call(boost::bind(&core::relay_deregister_vote, this));
     m_check_updates_interval.do_call(boost::bind(&core::check_updates, this));
     m_check_disk_space_interval.do_call(boost::bind(&core::check_disk_space, this));
     m_miner.on_idle();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -35,6 +35,7 @@
 #include "string_tools.h"
 using namespace epee;
 
+#include <random>
 #include <unordered_set>
 #include "cryptonote_core.h"
 #include "common/command_line.h"
@@ -1559,6 +1560,115 @@ namespace cryptonote
     boost::filesystem::path path(m_config_folder);
     boost::filesystem::space_info si = boost::filesystem::space(path);
     return si.available;
+  }
+  //-----------------------------------------------------------------------------------------------
+  static std::vector<crypto::public_key> xx__get_service_nodes_pub_keys_for_height(uint64_t height)
+  {
+      (void)height; // TODO(doyle): Mock function needs to be implemented
+
+      std::vector<crypto::public_key> result;
+      const char *XX__PUB_KEYS[] =
+      {
+        "cab4ae6148233461074c6bc4c72b8a53ee91d9cfbda5813c3422a3e2897b21e3",
+        "bfae23724257762880ec334b7f83cdda345ff677c34ef141e8ea5cbbe0f61f33",
+        "04932a89171e0a33e3a079e5c61a7454a5bff9fd467ff81cbc18a5ee5ff37bab",
+        "ea505c9ccf83d73654268562487a077423cde586fe5799113e93a8a0b46e9fe5",
+        "4931ddac1a7981f0dd7259bee59281cf540ba6a9ef59a10ef9fe504214ff1f11",
+        "fa0fe218380fa8cc642fad13855789273f9283512dab99010374122c2df92dca",
+        "f6b29bb886e2cf64de7b0887c84d821e96ec56f6e28903f4faa6fecf18b445dd",
+        "7123ae098051a459cf6fc2fdeccad6210136f6e55f8218439864a53501498dc6",
+        "b4aa98188bd958ad7dd10eb19b091ac25647c3b28255b6a02633f57ebf633c9f",
+        "1e4c7a3e7e7dec98e9b5da2ba8d8ea013cb71115a22e926ba060dd8ca9084004",
+        "23f2052a043c17f1e93558ff5fcf1a183c4139384c7d115b32a98d55081dc996",
+        "742db561f88c64e696cec912b8ad4faea78aac871d3d340b664ec63463664113",
+        "28630fa9cc33c0b8a518894becce01b8f0b4eb9f234e2780404dc751ae9d1d99",
+        "ccacea809b1dbe1dc5021281662490b55db41d86dea0715b6b1322a7c344d641",
+        "cd3beb0621b26f0b16cda9c759601997cc054c3e673fa9d91dd1ceb1542a2eec",
+        "40b8be419aff1126a31a2cbb6702aced9960c075919dc2fe44efabdda973a7d1",
+        "42237ef07f9f7570d31dd19fa1141b8ec0b23f9c976a744381452c0d2ea24b98",
+        "0a583ae027590cf6f21a76d6fb7b582d904cd3661fa59a00b1d8bf780e0b8748",
+        "8a60f7a39c88dc8b425a72988d577ec0f198bcecc31162c12b8f696cce441622",
+        "160dc084804efa96129dcc846ea9aeb793e5b208dc947587f2aa5dda4634a877",
+        "cb92e9e8ce31522eeb731b9d069ca4fb327df0f5c1df81c32e45cad5cffdc0f0",
+        "ac7e0e825120d28575182c86e36c6f05666192f573e032f036871969009fa1c7",
+        "89555379367ec70306a00b0460b468c0973987ed6c8084ddac3cf51c505280cd",
+        "7dc31ac32a88bce95808b07cfa27eaad30ebc319c64719a8b63ceacd0542060e",
+        "96bbc02ce1cb673cec7dc649e6ff111d116fcb1660a06a39d09755fd3ba8e133",
+        "7b10fa062ae91169166a32d29e585695cf9204375484252eda89d76ddeb5b163",
+        "65e318c3dac1013de3cdc47e097deca020fe18f12b4c496f7f63935bc99bc2ea",
+        "b34dc0a57f68f1049733e0f610f29ef70f72e5cc237edfc7844cc7b06645066a",
+        "2dd94991268ee71b2356e8d748477a29ddf1aef8a9c329a0279753c599f38c23",
+        "ab3a704dd71dacd1361155e668253ae70bca58cf790141c4174f47403696ffb3",
+        "ceb1256e951a434d2a274be8d33a4773f797207121f774897c43ba258c1f7026",
+        "8502b21a22da7494130f689b58b91fcd48a17071c5554b6c9ec11863caf2e179",
+        "bb25528e6278ddfc0fd91752b9d73d98f01acef361783528b0e6d6d7116c5261",
+        "f7d7c629a96063ed85e2126029e9406b176a45b4876eb22d979ce32eed5ac5d1",
+        "2e7c51924bf910b4fe5ed9d89a9bfe40222fe91cb70dc660bc2e21a8318241e7",
+      };
+
+      size_t const size = sizeof(XX__PUB_KEYS) / sizeof(XX__PUB_KEYS[0]);
+      result.reserve(size);
+
+      {
+        for (size_t i = 0; i < size; i++)
+        {
+          crypto::public_key key;
+          epee::string_tools::hex_to_pod(XX__PUB_KEYS[i], key);
+          result.push_back(key);
+        }
+      }
+
+      return result;
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::get_quorum_list_size_for_height(uint64_t height, uint32_t &quorum_size) const
+  {
+    (void)height;
+    quorum_size = 10;
+    return true;
+  }
+  //-----------------------------------------------------------------------------------------------
+  bool core::get_quorum_list_for_height(uint64_t height, std::vector<crypto::public_key>& quorum) const
+  {
+    const std::vector<crypto::public_key> pub_keys = xx__get_service_nodes_pub_keys_for_height(height);
+    const crypto::hash  block_hash = get_block_id_by_height(height);
+
+    if (block_hash == crypto::null_hash)
+    {
+      LOG_ERROR("Block height: " << height << " returned null hash");
+      return false;
+    }
+
+    // Generate index mapping to pub_keys
+    std::vector<size_t> pub_keys_indexes;
+    {
+      pub_keys_indexes.reserve(pub_keys.size());
+      for (size_t i = 0; i < pub_keys.size(); i++) pub_keys_indexes.push_back(i);
+    }
+
+    uint32_t xx__quorum_size;
+    if (!get_quorum_list_size_for_height(height, xx__quorum_size))
+    {
+      LOG_ERROR("Could not determine quorum list size for height: " << height);
+      return false;
+    }
+
+    // Shuffle indexes and pull out from quorum
+    quorum.resize(xx__quorum_size);
+    if (0) // TODO(doyle): Temp. For debugging with deterministic lists
+    {
+      // TODO(doyle): We should use more of the data from the hash
+      uint64_t seed = 0;
+      std::memcpy(&seed, block_hash.data, std::min(sizeof(seed), sizeof(block_hash.data)));
+
+      std::mt19937_64 mersenne_twister(seed);
+      std::shuffle(pub_keys_indexes.begin(), pub_keys_indexes.end(), mersenne_twister);
+    }
+
+    for (size_t i = 0; i < quorum.size(); i++)
+      quorum[i] = pub_keys[pub_keys_indexes[i]];
+
+    return true;
   }
   //-----------------------------------------------------------------------------------------------
   std::time_t core::get_start_time() const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -41,6 +41,7 @@
 #include "common/download.h"
 #include "common/threadpool.h"
 #include "common/command_line.h"
+#include "service_node_deregister.h"
 #include "tx_pool.h"
 #include "blockchain.h"
 #include "cryptonote_basic/miner.h"
@@ -793,6 +794,15 @@ namespace cryptonote
       */
      bool get_quorum_list_size_for_height(uint64_t block_height, uint32_t &quorum_size) const;
 
+     /**
+      * @brief Add a vote to deregister a service node from network
+      *
+      * @param vote The vote for deregistering a service node.
+
+      * @return Whether the vote was added to the partial deregister pool
+      */
+     bool add_deregister_vote(const loki::service_node_deregister::vote& vote, vote_verification_context &vvc);
+
    private:
 
      /**
@@ -963,6 +973,7 @@ namespace cryptonote
 
      uint64_t m_test_drop_download_height = 0; //!< height under which to drop incoming blocks, if doing so
 
+     loki::deregister_vote_pool m_deregister_vote_pool;
      tx_memory_pool m_mempool; //!< transaction pool instance
      Blockchain m_blockchain_storage; //!< Blockchain instance
 

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -773,6 +773,26 @@ namespace cryptonote
       */
      bool offline() const { return m_offline; }
 
+     /**
+      * @brief Get the deterministic list of service node's public keys for quorum testing
+      *
+      * @param height Block height to deterministically recreate the quorum list from
+      * @param quorum The quorum entries are put into this param
+
+      * @return Whether the list could be made
+      */
+     bool get_quorum_list_for_height(uint64_t height, std::vector<crypto::public_key>& quorum) const;
+
+     /**
+      * @brief Get the size of the deterministic list of service node's public keys for quorum testing
+      *
+      * @param height Block height to deterministically get the size from
+      * @param quorum_size The size of the list is put into this param
+
+      * @return Whether the list size could be determined
+      */
+     bool get_quorum_list_size_for_height(uint64_t block_height, uint32_t &quorum_size) const;
+
    private:
 
      /**

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -210,6 +210,10 @@ namespace cryptonote
       */
      virtual void on_transaction_relayed(const cryptonote::blobdata& tx);
 
+     /**
+      * @brief mark the deregister vote as having been relayed in the vote pool
+      */
+     virtual void set_deregister_vote_relayed(const std::vector<loki::service_node_deregister::vote>& votes);
 
      /**
       * @brief gets the miner instance
@@ -956,6 +960,13 @@ namespace cryptonote
      bool relay_txpool_transactions();
 
      /**
+      * @brief attempt to relay the pooled deregister votes
+      *
+      * @return true, necessary for binding this function to a periodic invoker
+      */
+     bool relay_deregister_vote();
+
+     /**
       * @brief checks DNS versions
       *
       * @return true on success, false otherwise
@@ -992,6 +1003,7 @@ namespace cryptonote
      epee::math_helper::once_a_time_seconds<60*60*12, false> m_store_blockchain_interval; //!< interval for manual storing of Blockchain, if enabled
      epee::math_helper::once_a_time_seconds<60*60*2, true> m_fork_moaner; //!< interval for checking HardFork status
      epee::math_helper::once_a_time_seconds<60*2, false> m_txpool_auto_relayer; //!< interval for checking re-relaying txpool transactions
+     epee::math_helper::once_a_time_seconds<60*2, false> m_deregisters_auto_relayer; //!< interval for checking re-relaying deregister votes
      epee::math_helper::once_a_time_seconds<60*60*12, true> m_check_updates_interval; //!< interval for checking for new versions
      epee::math_helper::once_a_time_seconds<60*10, true> m_check_disk_space_interval; //!< interval for checking for disk space
 

--- a/src/cryptonote_core/service_node_deregister.cpp
+++ b/src/cryptonote_core/service_node_deregister.cpp
@@ -1,0 +1,734 @@
+// Copyright (c)      2018, The Loki Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "service_node_deregister.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_basic/verification_context.h"
+#include "cryptonote_basic/connection_context.h"
+#include "cryptonote_protocol/cryptonote_protocol_defs.h"
+#include "cryptonote_core/blockchain.h"
+
+#include "misc_log_ex.h"
+#include "string_tools.h"
+
+#include <random>
+#include <string>
+#include <vector>
+
+#undef LOKI_DEFAULT_LOG_CATEGORY
+#define LOKI_DEFAULT_LOG_CATEGORY "service_nodes"
+
+namespace loki
+{
+  namespace xx__service_node
+  {
+    std::vector<crypto::secret_key> secret_view_keys;
+    std::vector<crypto::public_key> public_view_keys;
+    std::vector<crypto::secret_key> secret_spend_keys;
+    std::vector<crypto::public_key> public_spend_keys;
+
+    const char *secret_spend_keys_str[] =
+    {
+      "42d0681beffac7e34f85dfc3b8fefd9ffb60854205f6068705c89eef43800903",
+      "51256e8711c7d1ac06ac141f723aef280b98d46012d3a81a18c8dd8ce5f9a304",
+      "66cba8ff989c3096fbfeb1dc505c982d4580566a6b22c50dc291906b3647ea04",
+      "c4a6129b6846369f0161da99e71c9f39bf50d640aaaa3fe297819f1d269b3a0b",
+      "165401ad072f5b2629766870d2de49cda6d09d97ba7bc2f7d820bb7ed8073f00",
+      "f5fad9c4e9587826a882bd309aa4f2d1943a6ae916cf4f9971a833578eba360e",
+      "e26a4d4386392d9a758e011ef9e29ae8fea5a1ab809a0fd4768674da2e36600e",
+      "b5e8af1114fbc006823e6e025b99fe2f25f409d69d8ae74b35103621c00fca0c",
+      "fe007f06f5eac4919ffefb45b358475fdfe541837f73d1f76118d44b42b10a01",
+      "0da5ef9cf7c85d7d3d0464d0a80e1447a45e90c6664246d91a4691875ad33605",
+      "49a57a4709d5cb8fb9fad3f1c4d93087eec78bc8e6a05e257ce50e71d049260b",
+      "9aa18f77f49d22bb294cd3d32a652824882e5b71ffe1e13008d8fbe9ba16970c",
+      "4a7f7bffd936f5b5dc4f0cdac1da52363a6dbd8d6ee5295f0a991f2592500e07",
+      "118b5a3270358532e68bc69d097bd3c46d8c01a2183ee949d130e22f3e4a1604",
+      "627cea57ea2215b31477e40b3dbf275b2b8e527b41ad66282321c9c1d34a0c06",
+      "70c4ca12d1c12d617e000b2a90def96089497819b3da4a278506285c59c62905",
+      "e395f75700e3288ea62b1734bf229ed56f40eb891b6e33a231ac1e1366502208",
+      "9e6cd8667ef8f0e2b527678da80af2d34eb942da8877b1d21c3872e8f3e6b605",
+      "e86dc61f76023c370feb9d086b3369dce764058ff4523c9c1d1a44957910f809",
+      "d17c568d4e6662c67920b618436435a837241a8ccafad6684016f4371b4d6d07",
+      "97c416757a07054d505e7ef2ebebc920e19f2a88b05dd0c58d39de5b9bf10405",
+      "be5a0079f52509be69afadabd58a969fb439772ddf58ff3fedc3e6d9acbd0807",
+      "cf43ebaacecc33591ddbd985ee7a637de665a275099d0777c84b358408a50d00",
+      "6aa670f687da3026a836faecaaa2178442414e89dba8559600977ced60bda009",
+      "2ad782d57e3d5e500cf9025ec981c4212c76662fb6a98fa1726438246dbb1602",
+      "82a3b1d1ce260680a7ffe485f383fbd423d93e3f64232ef1c8ee40f05465540e",
+      "627b6b28e2b89d1d28a6084fc8adf1f1859d299fd4507332a0bd410ace67860d",
+      "a4092b42c1e8b08c86a7b6ed0719a25715d0fa3119464a7d400a414761d89e08",
+      "3f47aee16a97cbfb8129ae211ff28ad89ffc0435545ae036414e52e2fa05060e",
+      "691c003ce323c82404ee15405cdbc70e80763685fa5c46eda8c49205d735e60c",
+      "df5c271474a07df63e2247f98f425a95136b5aae1fbd610fc1135c803185c503",
+      "ad98c0a4ac23c3df8568480d55078970a1db42067f0ee32ac94f030f1df8f601",
+      "ca09d289d9b5eff9ae78cdbbc17a374e66481d510bb6b4231466c5237a267a0b",
+      "fee16aaeba4145e3dca7f3f8cc617609c16e1312a7c007dbdcec3a597ced5402",
+      "238a7696ac0a36391b9910ad7626585fc229af593fa22701c8b4c8b18990b901",
+      "9d3d4d20e35b7845df650fba04eb24602e142b89614462a780bc104d7defbd09",
+      "729cd68e3b0a8326c2cbd98a1eece2c2af3f9aa92a71f41e2a140a7ffc6d220e",
+      "cc99a1d53daaf60f4bec5c211047be10219cf414d7fe78b84a893dc970164d0a",
+      "5704870bd6ab0ceff4ef50053396bd539ef1d54fe4e95ad6eec06d272acf360e",
+      "0e62022d8f704d4f54f448fe31bcce7c4ea975a7a534b7036af87741f4a29700",
+      "eedfff5f46958b1340044c13853d5dcf9cd7bf7f2c0b7fc9bcf507b2b29fdb0d",
+      "a2e9c539b646957637897a93b7253e62955815c466474849287cf0b7270e6c00",
+      "9627273e472b68e6f8c7a228146e65cc7da97e85a3bf9d0a10306d7ed8da2602",
+      "efb04b20f01b9295f8066f84b90a795a0eda9ae714c8ca9be123eac678025d01",
+      "6a622ec2c0210357c347b54d2b0fb846ef5894a1f2ae117817ae6effc8b1800d",
+      "e31919c7f3596e625a98eb2407108c3760cffb5d0975c5354509752519316d08",
+      "5e053ac6e0f7725b1238798f5d5a09047db89f0aaf9c87e6d265bdce97360203",
+      "cfe967061830fa5277b8c7432ff9c2ef80159a1c201c63627cb88bf3ecd97f0b",
+      "a69c06422128e7ab55f38795b700af760a1bc7d5a08386d0c5f6f7e4a0367606",
+      "669b4227c299d9b615af5ea636b062c16fa2b1b12ebfe9a3d21c01ece7cd7207",
+      "fd3c1b477688cee1affe423772a5d20c2b6c99f1dc836f082d67f030ddf5330e",
+      "739ad42ba90d3f6ad7bf58d6471f9dc3a3a70c335497d27eb84866360396b70f",
+      "7ede7663967b311665d0dd4b93bb4eb6e0dbddbc1dd4f45d0d0668fdc1bf9602",
+      "eb52bf69cd99e55bf4b6a6c150108a7f9262b96c43e349e429f573bddc3cab03",
+      "56374dbe767e0bc5bb36c9b320884bb2b14978903964ca196054c4b63d76ab02",
+      "2d3a6bc00151bec3f6802db502c4994eef16df5224fe9004dccedb6542990b04",
+      "25291317fb6b7004086036d4c2afb93d17357b8927c05a86abf507c7066a3900",
+      "368e6263aec214dfed4f9cda9d61dd6ad5354df89ede955d5bf11aacb608be08",
+      "267ebbf081917b31073e4d24cf979db4761c1aab5972bc6f3fc14027b33d220a",
+      "f4e1c1221ecb5fe301ed9a6852a8bf32be8a171f4bf4eaf77fea6aa698cf6a08",
+      "2f11eab4c3c7625f1102b8af46bec768f70085bb3b358fc5e3d5c124c1a6960a",
+      "9e9e42e1a8cdf9329389ea727e091bd33de97bc39fd18d355a0e6c58346b6d07",
+      "3ae8b143ff3cb1c06b6623e0d4bb542ed4c777703b07e9c6c69a707297f51708",
+      "dd4486a5cc44ca4d1f8fb452f387727682eacd68fdf342fae72af4d7dbd48f06",
+      "b16e9260836c8a19b4bc082abbf096f184c24528f213b0cd137897914949ce0b",
+      "e139ea1f4d2f86d4b3fc30962769a0bc961205ec6a65bb31117d034561ceee03",
+      "fb5c840ad686c9ec2256f75ebbc9fcece5f2dfa8f02bfac587e56b052a687709",
+      "e1c199e70a77a7141e5be996ab887b6eaf865166b2d5b77a23581903dd211b0d",
+      "9813c6e6ea9a20a0ce9ceb9c3c153471bd54497ca5cf30348b791a7b2fc24f05",
+      "d2731a9f2c4406a3ed0507ae5b390ddef234c59f7d0eaa52e7f56e0c43770206",
+      "b61c77620ff596a7fa4f7562491bc3a77056acdfbe148507a8ebfab070b3c60a",
+      "b44172f3e97b65c55fc8b89dba70d5b1fe4d947e5877cb6fbc402a36500b910d",
+      "7566074ceb7da410088d0e40e10314831d2bf2ef2c347605ac00b9b5c1f22d07",
+      "aa34be55d15a3e9b8715dfa5dbb09c40beefe21c12eee541893b13998e95a901",
+      "13ead1a2c33c1db4814d55f015d177ad64fbf2481bdd24f5a709b92108f26f0b",
+      "7082548d52798708301b8b7235950d4c1a92804ae56ae449ca6a88abe30f3707",
+      "277f6f333a80796f352c39fba1a5da2e1b1c090c38170aa2d70f3127909dc009",
+      "664726ebc833a5bf99057247d067451fe5ceef71b73db8636829a9dcb737fe01",
+      "1300421958cfcf97fecccca4293abdc51d1032fadd09c41b84cd0a19615ef205",
+      "cd994d117edc22e7eb6cd285681852026423cafcacc52f05d0e1b71f1bf99202",
+      "8026fb72b2af35229a84f14badffbdd898d490c0c469d0c445322d2a07ee260d",
+      "2b7be54ace38dee69733a5cea14de60de61aa7504ba93d7a4591a53ef7947005",
+      "8816aa86e4e4d94f4785ef873810876bec9cba5488be17f653c1384e5d539f04",
+      "a92aeb6be2833ba4acc81985df8038da898998c243ad61bd2e91b58468d15708",
+      "9c14135fd4f93836b91348f051ce655d89b127dd25f9747fb903f7781c052302",
+      "9c85976687edb01c63bfe10b5bd5da5542e3f91484be66969c50aea01d2d2402",
+      "3a0aed78125f6a33a6ca342a33b3b0b8bd4f9fa9fed62058ac553af6080eb604",
+      "58857677e6619e89e3d7688a83eafdce0a93c9e0b6ff1baaadc7ad2229d2bf01",
+      "16c0b921ef146f0edb0a3617a222657ef3dfcaa855de0ff2b20fd35efe210d01",
+      "18c7f0a125f35fc2bf9b066ea44a428c7613c05eb08c21f06d151e4d2a0abc03",
+      "92f639ea36294071df576a5df3a6477617361543754440f2f036146d2f77130a",
+      "d672c81f36f51b20ba2c1fae33a0b10f06615bc1464d84904a3d749a6a9b2c0e",
+      "6439873d731d24fc1737e28914ed7b2dd919520699323f3c86a6a94827c13201",
+      "52261c788b9dd1982f2615848577f403611563f891400c43c21cfe8534ab2f09",
+      "64334da023fbb0cdeaeed9205c5cea14647c37c6d1178c5401795f12e7540708",
+      "eb6c797d2a135edf704d03053e71a0b734de22e157806db4726e9a3fa6de9401",
+      "3f41c8c2312302deb89669c8d59776173b0265ee058ebbcaa3ef55e82a474f03",
+      "fe09c62ed7e4b100a10cf4eb6be1f17acd6b7dbf64d15bb956a48a36f915e704",
+      "5b41d546ccd37e0b44bbd2f9cfe093fb3833f2b808c50b18aa8d4015193c5805",
+      "ec7a3e53f86bd14c756f852ab4772a6dda38f88b4f2bca702a7c4b2dae857f0c",
+    };
+
+    const char *secret_view_keys_str[] =
+    {
+      "737fec2ac72cf4875ece19bd84b4a86a8657fc8814814503d030432ea35fad07",
+      "2792f853846086f6583e71f2a9c1b981714d63e8190639c7d589ecb286250303",
+      "f585351851b784413443d56a3d815646b8ca1dbd8a077a132909032a21aba00d",
+      "f9d176b0372d2d2593f4e4bcc65add9cc28b8112db470ff47aa9ed841322d80b",
+      "c714ce94216173ff9c876b9c82faa4bdac34ea7532282342866aeb97d46e5f01",
+      "ad35f5bc4bdb981d98fff19f0f2aae136968236db259ddf90ef0600e9248c101",
+      "f96ddb40442d9706eb4f4d7ae3e27ddacf83bbc48db020bba1d1bc38bf453508",
+      "28d5d9c3417a4fb37f3ae836475dce828a3678d2e94d210b5451586141759802",
+      "e061f3f8556c25d876d346da36f44d0661d9fc4c51c1482c5ce3c282d0c97105",
+      "cc1957406f4c883ea1169186f9159ff8fb8c456dd93d541713439171ec81a902",
+      "f1d9641750120bc99d4bff33eb4da8653586c36b687944e38af4460471dd7908",
+      "74905fa3d930d297b16a9aae486054dbc9d5e123a6294accc823df3ff84db40e",
+      "d710e2381bb4edde894ea30ca2f7ba86cd9c4251aa86570d8732290828c5ed0d",
+      "a2214f8c4f479f5f70580956997dcf09f9450c3ca95b20b76dd48f8978ffda01",
+      "eea89d9c3bbd865ce8fec16dcc9b87274fad4f370240292bc5531ebbde362b0a",
+      "78ea92f16f9c13f90924aac5c8c6126ee31d963e59cefa0f27b0facd848a6d05",
+      "d3b49336a84da4bbfe1f6265d5e67aa983942df3c3261ba60bd9e821fbbbe40f",
+      "748865a870cd74ab20a83dd768875d0e84b2004824251fb4f02314d607ec7b0e",
+      "6e8648549d3b923b1c10fba5f1ec4c040a4a84754c9d741211a8f4f144b95005",
+      "ee2a42f8e96959fddc035a7b2e1b81d5fc2da9ee91174a61ac3f5c1325e66401",
+      "b55166a947bcabc449932f1a3f800deefe11e2a366e8027cd7a5671f8c7e8904",
+      "55523954dca5efb6dd8ad5bfbd4ebc49b71bd48360d4f85a00a2c6ab09be4b0c",
+      "e493a380eb5fefb05c26e76f432f7c84f9b751caa65db5ddb18cc65ab9ba600a",
+      "dc2c956a6fd2edad75a7a939a88743b83ca3fd8d56a46dfc7e86258bdb4b210a",
+      "8147bfb94daefe23b9a4c454ce0105c4ae6d274f8232863faae4269dcb62d10c",
+      "a9164f89c44dc21bb84ca31b1432e94d25e6cbddfcafb418ef629673fd0cb80a",
+      "b24253bee67bbaf550b12de16da51b5de5f2ab830c5dbf1613282601dce44906",
+      "e8af7f592123df6c2727c18ba294ffb0a4e26c80b7d126fb54970602b984c703",
+      "972e622ed037eb699a4874346efbeed520b46366291ff02fe010168b35ef280f",
+      "640c1525b92f3e6b7df68a8394a641dfbd8d11f834baa6ca824b8c09d2376001",
+      "9b0ea622c662e0b22c2d4afe293756235dc29e5268a1519444899a98544d7205",
+      "757383beab10787379bf01712d75ee83d35f9c3dd332620d9c11b653d349c707",
+      "711fe5f95ea7b424c9360af636bea607105e05475cf7eb9c3797ef3db9efb80f",
+      "184218af272c033d975f72efa401e5dcee36bb790d7373bad184fa256df78a03",
+      "420bb6c6181735e0a36f1f342b38945d76812a18d86d5c3ef65235cc98e1a409",
+      "427b3171531e1fb1f43b294ed0a23fc90199be6c1fd777307824ab8c3067930e",
+      "e646c5f8e7f204f4cab7ac5bc1ea327c84707a5ba509a87740c549ca4b950a09",
+      "9982526e83c827f8ad51d4eb3fe0f2aabb6ca82cdc9493041c0c13e8d267600e",
+      "afc855ed0391dfdb3fb182d2a8eb3181e532dc3e8de458cd3672649808ff7208",
+      "e6b55c3a1c873ca610dc9eca43089d874f4e3d0cd4bfa029f45ee1171ba52c0c",
+      "5110c743aeae5253d480235c0c6fc7118b64158baa74b9d140156da571b32a03",
+      "10567eba502edde7630a993e171897a49fc0b1e30264f4e5e76957ad2515e702",
+      "d68d48a8fb666dc4424bad90c44f346ec332ba9126208cfb9e23ff2ea281e70f",
+      "115e9158f22a58c83a2b39d1d465793c792ed4ae2f4e7cb4997ddba46b959600",
+      "989906935f111138ee14b6e056ff12dcddfc25941875357e4544a6a644c9fb05",
+      "20194837af099becc39295bbd30a438eb5a046db1d19c4587e81529a91a6260e",
+      "900873d956b98a01bfd225b17ca63136478b163fee78c7270afca8ec0381f600",
+      "7972e90ff14431f9bf5c977c7eb538290573c84859f03dcfc4cf8a2b9b888a0e",
+      "5cd3ccbfc6ad0c10fb2f9929f1fd12663949c30f3ce3001b01625c6a28cf1806",
+      "c3951b77f198149fe2d5907a3b437c38efc92cb37c5fe4710ac5965e077be701",
+      "7e16b4417a3c06aa579432a9dec94d54d12287fbe2033584f7287a5aae96ec03",
+      "18a9d46d27301be4e241ff3453cac976692e654041d5051f6d024c5b3c9a2d0c",
+      "5e060e5f9674a97bd08d698dec6214e7c6eb54e761968df417a8a703f0482009",
+      "cce9951abe2248010cddaab58f2e97ae12aef68b2997899e371ce4d8528b7804",
+      "2f9a63777ddf5b1e7450564345d7a4dca0e1cbc37e6384a822b400785429020e",
+      "034a8a81a36dbc998f527f78d6f8c791f71ad1b5960335f3b81193106d3e0b00",
+      "2bd238f8170492eba264fc2e1170f862cf716d6b55eb6b9b6d763c15aca9e101",
+      "f61c8f7d68dff0bd339629e28a41ea5673027e72635f47cec18a43db61cc5604",
+      "9795a613f288a860395ed9e6eb0f9d5a039ca9becc54a6e08717ac05574af20b",
+      "bc0830bcba5498cf39ba8ffe3844781e4949df158f16931423a0a61150ea3b04",
+      "0a5acd55be2647bdab1242221bd9718ac9a1871a199f5fb111b44e3d96c9b705",
+      "0c2cb96ae138c98a4a069dd000238db7e084abcab358d208430896649ff70200",
+      "15aea033ce829e18aaba1a8974923ed79b8a8dbc0f801fc6eb5ea76625d8680d",
+      "cfca11787b684e1ac00dddf70c8e4bbd8b87d55f4a12f575fb17db0cc132b209",
+      "7a4847bda21b408b449ed994d82d9ed7968d18e81b29cf9c42caecf76cb9310d",
+      "32edc2b601d4f8c0443c994978634f2500626020906ddab6a3c85e2c9d74ee01",
+      "c59bfdf6878473f8c287799c54ac88bd1f92c68de7fc5ed2d2aeef1468489208",
+      "d671166394bd14d821118401073b531af65408ac67a1d3f25417db5423279803",
+      "902b2660518c0e956e45131f8b9bc2c1f31527456ca93bc86f0ef560aec9aa04",
+      "a726955b135626717be1301d08fb507f9b694741c2954b9ba1fccec282608d00",
+      "c9afbab8eca0b15b4d6e80722bc3f1baddc312783e32648cdefdf329bc209502",
+      "ebf784323ce3dc283b2facb2d8ecbe35154fd0bf3de0d195b902076f8582140a",
+      "d4bb8fe6ae4ec3db1f3411291f78e10ffb9bf4b8f0b695b3ee4f63020d4a2a04",
+      "65dfdd392df2597ec6ebcbe087ed46668e06a3b437f85de3c965f63644b3370e",
+      "73b984b2b569707539d239cbbee6a2544b3a1ea68c98d035d6ba8ca3ec1ba109",
+      "4346fa6bc7cc339ad47b0a35b55d8e26e6eec2da557c1866ce5b3ea34a703709",
+      "20d6113050f3f80e7f71f81d822de8e16cc537ab0689cd4f831ff6571147dc0d",
+      "09b1bc0624a88d6a93c75cb55d5ebf37e4af357bb1e58c7de42d8610515f6b0d",
+      "17becb03d791c163019958aef4560c5061d3cd91fbdbfbfbcf5ad74c0150fb0b",
+      "957882a64c1c80caf7b1329fb2a0d9cfa939cb960d224feedf6e4df93e4e0f0d",
+      "fcc68b580b660cc46dcb216123e80ae82bb2740f4092c30d3d1d8ecb7302dd03",
+      "c16ae0301f5828df5d413f8af216597d70f3668b3915678c640edb518dc8730f",
+      "5cb1a8dac6d5a3336a792860fad6dc873f4b7b4a2c7aa8e209e1bc49d2c65005",
+      "1de37074745e115fb7d75afff1f569f5cd5bb771c622deb818fbc972c3557a0b",
+      "228e50d452077d9033547d98ceb86bff91b428fd9f1214ea0a3a4ede2747280f",
+      "8c118e2110b8b4cbd2f91c3f3cdec36ccf9dee801c2c4b09a556844e34c9e402",
+      "b9717aff09cbe5996f212e01d5d3f4b5eb9254b6e04fd5684d65a92fa14da50f",
+      "55da1eaf722d392bebcee4ba95df62955a488066e55057393835e4b27e54a905",
+      "4dfe88fa91a98a7a680922b8b47466da9cbfa4e87a5794d6f55397bb78de830a",
+      "dc04954929166773bf1049a1d44f90c34ebd16ea6a51de22c1ef50072b96e806",
+      "3b254cee6b1210cc96bd4ba8e2aa78fa10f0d3f6a1831e2e1895985c50525400",
+      "78b8f1bac64887b8532b18835fb174ce3dd01fc9d9ee7758a7e472609f24fe04",
+      "c1a336bf4daa38b7995fbbdb1c14c14fef3d0520ad14d0006b02e5cc2fe7f107",
+      "f559c613b7d62cf821cfc055944580e22988443c82fa214bb2cb016dacc2c40a",
+      "024ccb288a81dac0fe4822553d0d9fc5496448f5314801fb26c074db3216b808",
+      "72e80049a952c641787116b1a7030866248c6f320082aef53960e2b061ada603",
+      "ccf1dae026dc42c9605e9bcb8450110fc59cc033cf4f8246760028ebada36d0f",
+      "f21c2022617c3dc2f81b0ac64dcc71b93e98ee3af7ad22dac9bcfcbdaa816902",
+      "9b49ab72353b2fb4bbf9c7b429fa43005c09be94eed095012cd1f27cad96890e",
+      "4836f02569b16b46af093cf867cc977d4f372d263b637a77e4383761a8443d09",
+    };
+
+    const char *public_view_keys_str[] =
+    {
+      "2c630b80fad747a161af10a814b4f9aac058300025da9a6bbfb7a0a634796e52",
+      "7b4bc53fdd9ddc61a623d6cea943746047b6d9bfcb806092112cb25ea8960a0a",
+      "5e9b9e3ea45176ffea82a03f592a03849842bd04a7d5c8512a7e21557d2db956",
+      "a2781a9d29b79de5dd8270b384164bc7fe857c2b3d6fa6b1378f298f6ce57afb",
+      "9c54437a9968696f20c338b779af48a58c59e768236fba6365a380e183901572",
+      "b1925e24486922062745cf25bd9e84e59d40222ad95ce31ce627dc376d3eb7a1",
+      "29eff4d0fea74fb9faa42f7d26f64b55dee30eadc6d3e47a6350ef32e8899db1",
+      "87a73dc00d5743726b7b4534a17774785b86c6b8bdfd87693521663857f8e6ad",
+      "bc20c7283136482caa2d4711d5e6c503f17f43a6d4bcc395249c1ae086a85127",
+      "9bfb49aa2b9e98f7dac8e1d3846b197304d973618623467d6851fb47a021eda4",
+      "7e0863456869decbeaf1c1146d5fad2dd3649c73011eb77fe4322ea5f062c0d6",
+      "0fa37f21968edd070c9e6114fc606a47832981470f0ea26506545aacce439ae3",
+      "f312d09c8cbf9d248b5b534107d3a4836b242843e094bca74b457a5950260e06",
+      "129da689cbd4af8f30712f15d334b55708c87f291a5f13fcb7b3856316fae48a",
+      "192d734eb917081a51e5de66d191f3561a4a18e79a38133792f109e7d80baa94",
+      "925fa20ba0891cc162178389e2aff803398734b3db91996504e7ad26ccf9daa1",
+      "c303bd7c1ee139b571d0fce233eec4fe1de1c20c73a8c3a59d7384f5e259b800",
+      "49d7dde44c90f3e761229d2200985c027adc58e9c3f95ef7f236b8e527f5d76f",
+      "d2d78e19f70fdedfba513e6491a35ab89d0a34c692bd02975114e26e6b73c3d3",
+      "f53a7d2629a82c8dcd88fc3cb3d48c402982186beb1c9621d056cdc4f30fc85d",
+      "5347c77ed9c8dd61225bbf76865c72f0662c73d8b36cacbb612ae1aafb817dc7",
+      "5369a23800d3924281e137569055725c8e350cdbd9ceb08c0abd5d9ff5c63d8a",
+      "bc160c1b4a1a8828fb6afeb618d31fa5805cd924f0dd7b9e5b51569b1c7db9a6",
+      "60aa7e0699cbb55f564ff130092bc46936fb93716b09b4dfe60cb4a8d113ef1b",
+      "65fadf79b26fc6a2b2cbb746a9d0a060c8bb94623cf0d900566ab215014459ba",
+      "c88f50cbacc23da423c161946404dab6073731ea6765978a7b4443e912711c98",
+      "7bb5b09721e359e91458c814e9c7ca74c824704fa731ee21361ab082fdbbfb06",
+      "1d0327ae46205449127fdbd0a97c17b6cdd087a487bc9c5f74dbc2ed5164c31d",
+      "728f3379c9478bcdef9314e92e096d290aac6406c3dd2812a6922df0f1b9c954",
+      "349e42cd005a5aae52179ca0d20cef252bce3906850afa34a5873b68b6541f77",
+      "9a84f8834d9e7ccc88fe80f91d1d87d38a0598073c0445ee2e07ea8069fff92b",
+      "be2074edc12b57868ded1ac11b8378d5e82ae889702e86955be65a4cdea37aa8",
+      "80da793be3b8aec153f019a3e89d54fafee0d8737f2ea683c5ddf5da53b0b373",
+      "eb6e29bb1a2d8d7859bba48a592ceabe2c93ac048ce07e948d95ef37bdbc5b60",
+      "261d1b23a6ce42ca2b28bb735a67606c368b086b34e1ebd2e4ada952f7ac5714",
+      "b192a074e01ddd287a87e012bac0f227c07739dedcb55d15ce4c669ad542b63c",
+      "d6f1bdceb7ba8aec763955093cfdb37011c90e3a36b7cc5adcb318e05cb52457",
+      "9d8fceeecbf02a79f0ecda7f3d505227ff298cf5b55d64d37e654afdd4bdc21f",
+      "06c2cbf7dda109ce31921d3f9d76f99b0492fedf4fddf3da9dfb0efb0618a51c",
+      "d8c6439ffbd9accfc39faea2df62f3540ff5c60c8277597153aaa34c12be4af4",
+      "581b9728eed3fcaee3e8d1c6183fa2e880c8ef3d4714ac985e094efa1086b054",
+      "035790f51baf5c3c7cd604e27b0e74be467751d283165358adc059e46be20aa6",
+      "de8a25950b1c81ed511ad921720eeac4bc9f0d17134be4adb23e8caf41971d6e",
+      "92046e6aae34dd600197e004f481423eff7c9693c9f1e2286fd2a656e9ce64bb",
+      "36701b256ce965d27e6977e615512dd3ce6956bbf751dae6e465d6b02069717c",
+      "0c539f30ba349133e2f376c8f29b2b3689b8f5d36d38ebb8ccda1b8e828173b7",
+      "de132fc4548cd2496accae2a7d857ca7114d62de5ae26fada431c048ed245222",
+      "a9fd335e2141c4538b466d4a116835af99852d5d610463885d40d3beae26dd8c",
+      "1f325e76b320f9abb1445ae4dd39d8103bf4f9fee7b5b1f8b163a80667a2762a",
+      "3b7a2246408813846eadaf1553f60c225acfdd90b87a0aa5c9a4c44611b40bef",
+      "a7d470d9b36dab58b364c14caad5b046b456998c23ef9dc0eaf103d1da9501fc",
+      "54d5858d388e46a3ec92de308ae82451acd1b6d3928c83d10e780726dbc2b371",
+      "0fead8295364b90e9fb1d274a51afb8a0b992e3556a2f0fc9958bdb593e36e19",
+      "2801206f7ad36ecb3b6e5b582b496745d23c11f972ac64971f9c740699a66dc1",
+      "4b4396b22d9f0b585030574f99deed1d0b5f2f69922c79e32697651374cd1179",
+      "4e77617debca36df10c4bfbae0915b88f07f0b16b5316658e78e9463b122c73d",
+      "6c2ceb393e764c5030b58626364175b9ee89228f5604454004cb4aacd425e651",
+      "1adaf92bd1aff090d5846bb56bec502bd1a2eafb18cad5e9bd1d01949573942f",
+      "b48be8689517e34098e0a77e9c8a6c1fc060b15fcebfedb49d3d1ac3e7d069ea",
+      "0b011358197a66c2fc0585fc833159aa99c461c12c2c3a16a4cb42ad4246d508",
+      "233c031787e953dc591db478cf1b82a7f2f5268d48ad7661804804307961754d",
+      "9828db88fd0838ed0dcc8d872e7486789d00cf029d3845658cd699f9cf99750b",
+      "8e61f39836bd359bdf2c4a1ae679a319b62d4b691beab83e8af67aba9602d731",
+      "5860af4708f62db5b24a73212709240bc840dd4293e0ed65b8ab222c4c798225",
+      "cb9a8fa987fb06446ef2fd0ff1a05f06400b4436acdf31f76df30127f2bc5291",
+      "2e2c1c675762e2864ee93d7ead0b007377e3785d4682aa83f043fb8a4349f33f",
+      "d8da4726bd6896c3cfea0e154f1b02ebdaecaa044e023c25c17d4d38da85537b",
+      "6cde4dd8727a74e5af5b632c8a91b0c74824ff25b9f42046b7a48597a86e0690",
+      "14932b87eb667bfc38d7cdeb46796bcf7adb19db3fc178f55178e2690399d1fc",
+      "204b752b60efa2f67712a61d489c34e21d7595646a6386dc18984821e5d322bd",
+      "097eabeb75d71a1caddfaf97dd1b9a9ab4da42affbae6874f2f77d23553000cd",
+      "530d9f9bff1d74368f272a44f17bfb91b26085db38de15738ad9c86d052074f0",
+      "5d34ceac0be957241a0cacbe66a8ba2c312fadc892da65b032d974d80e009400",
+      "9c79265573974daa840ef4c91399a1c66b32b774cb76fa5d15e15906b10d81cc",
+      "4be5b28a7235d51abeb66faaa5ae2372da1ae1ce55de30866417b74479417cc6",
+      "4f78ac9268c4000ff7fa29a00e1153b69bef8039c9d3dfa0bf52029966e54b11",
+      "a8906550dd9f70537f3ac28f5100708f7b1d602f280e7570fcfcc344fa339d02",
+      "ba19c31f84e363be4f8534d8423e03de41f60d650aaca403e4985ed047f41e24",
+      "a017c73465177a707c62a69be0a61ed03c9028d710143fdb8238b2167d833fe2",
+      "2d12a117eb93de1b4ca651ccdcb0cb3f4631af2597a76a411167f3d72284b6bd",
+      "82cf3b27553335165b974a100d3484a449aabe9fd9059fb7fb4c05fc591e4494",
+      "8e7929c14dac7282d622f3f29529811c5924f53401fe60a471e9fece3d32f2e9",
+      "fb31dd1215c4527bcc7edd7184112273d0e4de379a9daae2ef537ea532499a7c",
+      "631be1e296716f064d7b0f5f7f133728dd55cda06fe798bb892aab191d120b49",
+      "5d77438469318b23c5bf26d298e3fff0ac241121bc95e320da92f7fbf2dfbd8b",
+      "0fcd2774c95aecc71419ed03f386e7d7ba630ee49ab29d44dd01b8eb71c0b045",
+      "5f3292584e7eacfd120d7fda25870bf2c6f95665f9f6d4166a461dfeac913e9b",
+      "c636cfc439679e2852751d3781fde3889c812d8b246732477b12362ab5995ee6",
+      "fee12d8dc1505520e8dadde1450b17bab96ec61277bcbcfa61c6f15f3a207cd5",
+      "243acc241270a8f81fe4f160ea809831be197700f009079c9bda3325e8d92a2a",
+      "b3cc931d3d90c42da64e0b2338d86018efacde14f1c284cd7594dc88fd88aaa1",
+      "fa5cc591c9cc5e0847d7da82c717f8d59d1798f77c245ad0e5c457a373ef0953",
+      "a6f04634b070c422612262e718cbcf1269dcfd12aabd0f1c1ec52630396587cf",
+      "6dba976dadf612423dccc272a420da009fb20152ea9ac501e58f5eca227a6ca2",
+      "a343b3e4abdf29dc6bf63a57faededf59cf1825ccbcc0a5ffbf68d42a6452e7a",
+      "b011870d4ddf0fb0d8bc91ed71f11b0bf85a7102bd0f405ed49ad21474992f81",
+      "24375b579071a728b3b72f49588a41a89dbc38a9e7f957182a2dc129c3f6c646",
+      "7757accc4647fb219e9e8c211a8e7f6673b7da2b3f8e05cf8ab4c4673bbfeeac",
+      "1be0b206ff9aa683f3327c6f6ffb4d6b6fde62704aba9c8e7c3b7fa308c56985",
+      "42a2c97ac24d9f4e1275a4d1e5f1504f073552e97631075e20fe185dc4fc27a9",
+    };
+
+    const char *public_spend_keys_str[] =
+    {
+      "8112b90e9964a9061f613481e6f4e2d5cf873af2e7e9d492f0b0959c0223bc66",
+      "67fa0148ae72db4ef4f46e6c455ad06b5c366c3f512df9743e73c679f644e1df",
+      "051b4e9ac85d5af824b5da3a25e87bc19a1411ed4a3f13517cf3c42452f27b4a",
+      "3cd2d156c9a0ec53da9e2e724a50606e0a4597ab28120874598d6a2e5e429e11",
+      "642e4586fc8ff9e55c28fc3e80038e0c92fd4f3742606c24febaadabbc26a60b",
+      "40cb0e9ebbdf0af949b52f356e4e9de03120400c738da3c6d71e417c20c6ea30",
+      "c88d9870357dca73e93c1aad905f3bedba53cc4ff628304bb3f85f96bacad683",
+      "12dc36b2385b7d88457d0bb7189b632b4d5493c4d0c29b449858696d89075961",
+      "4a7cc216e825ae51bbdb327c7df9813752cff6b95cd9d95f9bcc088ce0ec2809",
+      "e6d98067124ab82418343f4c52dff26f5e0ce7ef56f72f219fa041b60dfcf662",
+      "5c4ff6ea89259da30778fc8f09640d3b29b0ec8d0363fe30e9919711cc86d136",
+      "80776fbf7bbd1adc84e1cc7b42277ac26574b5db80f030ea28abe646ec967c0e",
+      "9adec9a2dd79fa29ce32a7b2c3a3e398fe6ee512e77820466b6db5e93d81a547",
+      "7244bc075fd999d336f6337b007f3dfc83f0972a94ac3423a262a4bc3654befd",
+      "cfb6d881d623112ce74fe871b5719178e6b1aa7cd1b4e37ff7b2bf3d5caee0e0",
+      "1c52e02b7c2ec37b151e910cf522777e5efd6d636b648fac289820989d661795",
+      "1293e8d0dbd94130b651acdef484bc50ddaa01ee07aad79e8e5d9f08a1e07c13",
+      "d3074f9ebf5724cb7da1b23aa8232da5c1f3f0e4cc2e4cf798c88e0b2cf9f148",
+      "b52ac252eaa304563a91b7f29d3da6b5a0e4cb0ffa136db7f0705be49cd40e95",
+      "d2193ae488a7f90fbef224c2cb2800a5f6bf79a7314eb25a4461d92f7d9b5054",
+      "1956c459f08e0078d2295abaa73b33f43a3474e3f95fb8657629e85dd680c2b0",
+      "a1a26e5651f329d1434ae906794b219030161df240cea77d3d7ae11c3e91edcb",
+      "0b5f5d296cdaca7904f78e4bd88e04085b145c8314b11a752bf4f5a01e20f820",
+      "2e861a10517196e7a19ba83e8d2899e28139e3eab4ee6b5d835ae231efcc8643",
+      "ed59a8bc43141cfbdcda55c6b2d66a171f3a4168d4ec3fac4cd4a3632c7a94bc",
+      "d9efe1d471e9dfea80d881ee716889433a06f76d6aaa3595cae757af94cd4b1a",
+      "a101258ceb4cbec028df0170aa2d6b47e76c111c46a4a3fda8cd186c8e73b041",
+      "babdb97dbb8d00a43083073630f09eb3e3d1538c603fd08d7aba0c3565d9a965",
+      "149a109af884491f4c180b0b81ae95f5c6b3b391e527f9523d490bea93233a0a",
+      "11345ead6ccf05c5d4e169ec72e1cb05689410aca17ba1915ecbdbc1f673b540",
+      "f21c2d6a2603c438bc9901c6b14adee2badd8231c705c037181f1245bb993566",
+      "7f35907dc0c5b1ee069a87cea06abf22137276461054c7ed6f9bb8a25a0d82a7",
+      "47ed53900ab92bd7cd6c0800687df2ff6fad4d07a6ba264df1143950dc888247",
+      "f5dc6afca3a13a5efc0406d6a463ca8086e3837f2502429eb17dee2220f6c906",
+      "8115f7fd2d8b62ea64518e1fbe48ef11e687bd6370e8217478af4567ab3e1879",
+      "dd2c3f112172fa9865a7c42ef33031404660e8645ceba9ce7bb2945814a15a8b",
+      "f09c90170740c04cf1ee3decd598bac6e262199d456a447727bd9f6dbc8c3dca",
+      "dbdae9f19645c55d6e0843350d5b7d5e8eddfc144ab74b0a470f313b380e4f64",
+      "3e78c14eccaaf6f98c2ffe3bebbe69ddbad402bae06391aa2ed4b5fd93ec6c43",
+      "4602fa2e47280d486cb18d8238f23e30331beceb00c58234189524202c481e2b",
+      "cf526fa79e7ed3a1f9814a4d45d10dc2ee75da920542ce777108547ed57afcc0",
+      "703d9bb2212f0f6dbdee7599ecbc83eee14858dd41448d0aa9d96d36569a3aad",
+      "89d608e2abbab5e4bcaf5787ae9b22b1fb1f617369427362505484bc95a76581",
+      "19e3a6327de2c4fd44eb5fe25b2a5c9132d97338b2eeb06e05c7aa2b76d10b8e",
+      "8a9a2d98cb8ddead192995b7738b50dbc1478dea1b9c99be3c6367869b4b096a",
+      "f1d1490a9cfdccb1b886fe2328421052f976ab397a41a5096caf8792ebd75707",
+      "8f5450be0346f7ec18c462d9108e06cca07b888db81c3cdccb31d537c5fdb1d1",
+      "032fb106ba4b65c6938b07db47b803e81f14dc3c324ef842c7fed5a5ce12944f",
+      "fea9714d230c903b11c75f32d3b4de46429d668e01b442229683380f267f07f3",
+      "faa87ff814c3021a2eaf69a24e603931c0c100b2075c3d12c885bbc7dcd5bc85",
+      "efbf84ef98c4a8532f075677b58e1100962ba429bb985b01e20fae5d5c2df9cb",
+      "ad5040e034502b61234d7e708be9351c6e00d450927c50ec9a32afdf02b36a1c",
+      "b6021473975651f96a4d36b7be88e63cbfb2d418d4d69773b6c64452fc9a64c3",
+      "fef9be8be517489c55878048cf3403a6d7f9fa43bfce8ee4d24bd0bc559803ca",
+      "eeeea05419a9b71a62d395bbe8a2b94c98697593850a944b81bbc8ec752a6d25",
+      "18cc025726737d7d1a95c9b500d31d2059c96a267a5a0b53be15425b699b99a3",
+      "d43846fb6b532ecde8370d389cb4420b11dbf4a79c18a1bc5783933b3a5952ea",
+      "15db8f1935d182446551bdf67a9f2686801430757656073c49f92242b6e3fd4d",
+      "955f211e7a7e8c5e02d0cbf5599e0a740659d0899ab66bde0c7aa57eda540f53",
+      "1ccf76b6ed8112c211fc9de49d6fe4cebad3459e815482ead997fb6f1f0ec74b",
+      "4c32a035f31bba251aba3716d5f985a565c284e9125cced44057c58c37cf073f",
+      "746ac173ceb1d055d77ca0ec0256286c743a038528c82f308339a6550afcf6fc",
+      "88434c2fcda22f90e601d96da2a2276786a62e4e0b318b5d7cc1542b75a5f60e",
+      "fc828de1199f1f763a557967311eaf9791c8f269adc332f2298c98ad325b179e",
+      "993044fb5455b4d3d8182c941ee5e21e3fe815cac526db676e8304c8fe367a41",
+      "2367ecf98e90636b4e3e334f5a022f4d4751a7836688c5fc40c9cf411355fb26",
+      "d5b2df0d0443eca488bfa2d7680a7e1f1f16dd76d7f10297598cc44e2de2c9f8",
+      "faa47aac5e932f4878ef16f7f7f4383a1ef6050db070d366c9f98cd8ff775599",
+      "b6a272db0b6b6397d424195a59efaec56514e7e21cd76191a2b4ec6cd83dd9a1",
+      "ab1bb60b858effcc35cf2111fc9cdb6dc90d371b9345837eb3fba32fa0354a81",
+      "0a1d730f410c5e8aa6e17c76502ce584d4e5690a0ef3e52352a494ba9630e553",
+      "77528bb167e40b13c07ab65af9268da61601f2afa0e7447724c7c31672fc6558",
+      "8bfff17b7dc4b840717f62fda573771e81dcce2a911919df8e3b3925f0ba181d",
+      "31aa9780b8770003a90c456a761654d0f13141e9ffc7dfce74c5d876a1b6328d",
+      "879a7d9b2482a397b9dea8f9e6e91135da300cb9b1d2377241fd7ddb7d251c1e",
+      "b9e14e77dbcb0711427aeabcf118c7d80d6998269a887a44d49639556066bfb5",
+      "4f7d926bfc5f9a264a3a0972d09087f38eaa76b2879e61715d01017194386a72",
+      "3ae858e31c725bdc414984b3bd51c811a8cc3be60cc5d5825233d40afd8ece43",
+      "f1601d0e7000065e0a23a25b83d0115c44749deff8037241caaa2f2677bf24c5",
+      "851f450921e37545a804c63bc10d4d403eacc0aec823ad861c5233e84aa5e192",
+      "01494ec0e954c527ebb3dced7d8e0c1a2ef95b1183034dfdb70c8345d507490e",
+      "592010c8de072ac789e792b63e50b9048aecb64b0edbc8a7e0bb41500e10cf3f",
+      "d8e9769b34373e7eb2f82b91dc5046714595d8f80d1f8793ed0e84798c527ef6",
+      "095237eeb750ef8c0c10c96e89a54cfa448cac8f031ee2007700e5b11becaf3b",
+      "d685543dc209da64006fe922e1091b4b683ab6f05e6695133ad75f7762df1d17",
+      "c993d744c77580361968411ae1201ea0514a002825d7aa0af2d9428ef621e6e8",
+      "41c4948730283f4bfa498819444c03cf8eaa159e9fb8ad02a7364c31dd182279",
+      "4ed4b99af67859e051f49bb4dfb08c2d1b60993ad64752d326688db191dd7eab",
+      "6081920bd10a4dfc3eb8dd29e8fa7791f450a8081b6659af335ef87da30779aa",
+      "d66ac6f8dfed95688c1dab37129fcf6af793ec694d2afbabd4b488b8e5248d46",
+      "23acc0688ab2c620b5bab815f4685ccf7b39c09fec52aea539a6c29f794b1bde",
+      "fc1a3b72e819e5af4e64663ea959efd6dd91a1e803aaa80eecbc0129ac44728b",
+      "98c5fc86b4700ac8280500707e9d368b2330ddfe75329d915c55ce628abd942e",
+      "cf7fdb83942a2f4f4ed3acdc8a3b0a67b9561b8d16cde61ae5f821150498a537",
+      "23d0a95a178863b2c70685ef01e335452dda09e541aa5415830d73588ca2d702",
+      "bf4b8963a41856fd1629a9920bf8c47a177d874b88e957651c5e31e6b7dab3b4",
+      "8f487cc93154b36d423cd74db955320d22956fec83d484a68747fcc83682f7c3",
+      "6c43a23dc0d0b0496d4fc35434d4ae8ccb26e5d444ac1a1187fac1062f3bad6f",
+      "47138315af577191066a762eb34789d93266b9f2b2bede649c49fa13d6806bc6",
+      "f87fe98e826ea34eee3ff755178cb0bb8fa8d2775d51d761f1681253226e6720",
+    };
+
+    void init()
+    {
+      if (secret_view_keys.size() > 0) return;
+
+#define ARRAY_COUNT(array) (sizeof(array) / sizeof(array[0]))
+      secret_view_keys.resize(ARRAY_COUNT(secret_view_keys_str));
+      public_view_keys.resize(ARRAY_COUNT(secret_view_keys_str));
+      secret_spend_keys.resize(ARRAY_COUNT(secret_view_keys_str));
+      public_spend_keys.resize(ARRAY_COUNT(secret_view_keys_str));
+
+      for (size_t i = 0; i < ARRAY_COUNT(secret_view_keys_str); i++)
+      {
+        assert(epee::string_tools::hex_to_pod(secret_view_keys_str[i] , secret_view_keys[i]));
+        assert(epee::string_tools::hex_to_pod(secret_spend_keys_str[i], secret_spend_keys[i]));
+        assert(epee::string_tools::hex_to_pod(public_view_keys_str[i] , public_view_keys[i]));
+        assert(epee::string_tools::hex_to_pod(public_spend_keys_str[i], public_spend_keys[i]));
+      }
+#undef ARRAY_COUNT
+    }
+
+  };
+
+  struct copy_region
+  {
+    void const *ptr;
+    size_t num_bytes;
+  };
+
+  static crypto::hash hash_region_to_buf(void *buf, size_t buf_size, copy_region const *regions, int num_regions)
+  {
+    auto *buf_ptr = reinterpret_cast<char *>(buf);
+    for (int i = 0; i < num_regions; i++)
+    {
+      copy_region const *region = regions + i;
+      memcpy(buf_ptr, region->ptr, region->num_bytes);
+      buf_ptr += region->num_bytes;
+    }
+
+    crypto::hash result = crypto::null_hash;
+    crypto::cn_fast_hash(buf, buf_size, result);
+    return result;
+  }
+
+  static inline crypto::hash make_hash_from(uint32_t block_height, uint32_t service_node_index)
+  {
+    const int buf_size = sizeof(block_height) + sizeof(service_node_index);
+    char buf[buf_size];
+
+    const copy_region regions[] =
+    {
+      { reinterpret_cast<void const *>(&block_height),       sizeof(block_height)},
+      { reinterpret_cast<void const *>(&service_node_index), sizeof(service_node_index)},
+    };
+    const int num_regions = sizeof(regions)/sizeof(regions[0]);
+    crypto::hash result = hash_region_to_buf(buf, buf_size, regions, num_regions);
+    return result;
+  }
+
+  crypto::hash service_node_deregister::make_unsigned_vote_hash(const cryptonote::tx_extra_service_node_deregister& deregister)
+  {
+    crypto::hash result = make_hash_from(deregister.block_height, deregister.service_node_index);
+    return result;
+  }
+
+  crypto::hash service_node_deregister::make_unsigned_vote_hash(const vote& v)
+  {
+    crypto::hash result = make_hash_from(v.block_height, v.service_node_index);
+    return result;
+  }
+
+  static bool xx__is_service_node_registered(uint64_t block_height, uint32_t service_node_index)
+  {
+    // TODO(doyle): Check service_node_index is in list bounds
+    // MERROR_VER("TX version deregister_tx specifies invalid service node index: " << deregister.service_node_index << ", value must be between [0, " << quorum.size() << "]");
+    return true;
+  }
+
+  static bool verify_vote(const crypto::hash &hash, uint32_t voters_quorum_index,
+                          const crypto::signature &signature, const std::vector<crypto::public_key>& quorum,
+                          cryptonote::vote_verification_context &vvc)
+  {
+    if (voters_quorum_index >= quorum.size())
+    {
+      vvc.m_voters_quorum_index_out_of_bounds = true;
+      LOG_PRINT_L1("Voter's index in deregister vote was out of bounds:  " << voters_quorum_index << ", expected to be in range of: [0, " << quorum.size() << "]");
+      return false;
+    }
+
+    const crypto::public_key& public_spend_key = quorum[voters_quorum_index];
+    if (!crypto::check_signature(hash, public_spend_key, signature))
+    {
+      vvc.m_signature_not_valid = true;
+      const std::string public_spend_key_str = epee::string_tools::pod_to_hex(public_spend_key);
+      LOG_PRINT_L1("Signature in deregister could not be verified against the voters public spend key: " << public_spend_key_str);
+      return false;
+    }
+
+    return true;
+  }
+
+  bool service_node_deregister::verify(const cryptonote::tx_extra_service_node_deregister& deregister, 
+                                       cryptonote::vote_verification_context &vvc,
+                                       const std::vector<crypto::public_key> &quorum)
+  {
+    if (xx__is_service_node_registered(deregister.block_height, deregister.service_node_index))
+    {
+      bool all_votes_verified = true;
+      const crypto::hash hash = make_unsigned_vote_hash(deregister);
+      for (const cryptonote::tx_extra_service_node_deregister::vote& vote : deregister.votes)
+      {
+        const auto* signature = reinterpret_cast<const crypto::signature *>(&vote.signature);
+        if (!verify_vote(hash, vote.voters_quorum_index, *signature, quorum, vvc))
+        {
+          all_votes_verified = false;
+          break;
+        }
+      }
+
+      if (all_votes_verified)
+      {
+        return true;
+      }
+    }
+    else
+    {
+      // TODO(doyle): Update the log print to print out the correct bounds
+      vvc.m_service_node_index_out_of_bounds = true;
+      LOG_PRINT_L1("Service node index to deregister in partial deregister was out of bounds: " << deregister.service_node_index << ", expected to be in range of: [0, ]");
+    }
+
+    vvc.m_verification_failed = true;
+    return false;
+  }
+
+  bool service_node_deregister::verify(const vote& v, cryptonote::vote_verification_context &vvc,
+                                       const std::vector<crypto::public_key> &quorum)
+  {
+    if (xx__is_service_node_registered(v.block_height, v.service_node_index))
+    {
+      const crypto::hash hash = make_unsigned_vote_hash(v);
+      if (verify_vote(hash, v.voters_quorum_index, v.signature, quorum, vvc))
+      {
+        return true;
+      }
+    }
+    else
+    {
+      // TODO(doyle): Update the log print to print out the correct bounds
+      vvc.m_service_node_index_out_of_bounds = true;
+      LOG_PRINT_L1("Service node index to deregister in partial deregister was out of bounds: " << v.service_node_index << ", expected to be in range of: [0, ]");
+    }
+
+    vvc.m_verification_failed = true;
+    return false;
+  }
+
+  void deregister_vote_pool::xx__print_service_node() const
+  {
+    CRITICAL_REGION_LOCAL(m_lock);
+    printf("\nReceived new deregister vote, current state is: \n");
+    for (auto const &deregister_at_height : m_deregisters)
+    {
+      printf("    ");
+      printf("block[%zu]\n", deregister_at_height.block_height);
+
+      for (auto it = deregister_at_height.service_node.begin(); it != deregister_at_height.service_node.end(); it++)
+      {
+        printf("    ");
+        printf("    ");
+        printf("snode_quorum_index[%d]:\n", it->first);
+
+        const auto &vote_list = it->second;
+        for (size_t i = 0; i < vote_list.size(); i++)
+        {
+          auto const &pool_entry      = vote_list[i];
+          const std::string sig = epee::string_tools::pod_to_hex(pool_entry.m_vote.signature);
+
+          printf("    ");
+          printf("    ");
+          printf("    ");
+          printf("[%zu] %.*s (index %d in quorum)\n", i, 10, sig.c_str(), pool_entry.m_vote.voters_quorum_index);
+        }
+      }
+    }
+  }
+
+  bool deregister_vote_pool::add_vote(const service_node_deregister::vote& new_vote,
+                                      cryptonote::vote_verification_context& vvc,
+                                      const std::vector<crypto::public_key>& quorum,
+                                      cryptonote::transaction &tx)
+  {
+    if (!service_node_deregister::verify(new_vote, vvc, quorum))
+    {
+      LOG_PRINT_L1("Verification failed for deregister vote");
+      return false;
+    }
+
+    CRITICAL_REGION_LOCAL(m_lock);
+    time_t const now = time(NULL);
+    std::vector<pool_group>::iterator deregisters_for;
+    {
+      bool group_found = false;
+      for (auto it = m_deregisters.begin(); it != m_deregisters.end(); it++)
+      {
+        if (it->block_height == new_vote.block_height)
+        {
+          deregisters_for = it;
+          group_found = true;
+          break;
+        }
+      }
+
+      if (!group_found)
+      {
+        m_deregisters.resize(m_deregisters.size() + 1);
+        deregisters_for               = m_deregisters.end() - 1;
+        deregisters_for->block_height = new_vote.block_height;
+        deregisters_for->time_group_created = now;
+      }
+    }
+
+    bool new_deregister_is_unique             = true;
+    const uint32_t deregister_index           = new_vote.service_node_index;
+    std::vector<pool_entry> &deregister_votes = deregisters_for->service_node[deregister_index];
+
+    for (const auto &entry : deregister_votes)
+    {
+      if (entry.m_vote.voters_quorum_index == new_vote.voters_quorum_index)
+      {
+        new_deregister_is_unique = false;
+        break;
+      }
+    }
+
+    if (new_deregister_is_unique)
+    {
+      vvc.m_added_to_pool = true;
+      deregister_votes.emplace_back(pool_entry(new_vote));
+      xx__print_service_node();
+
+      if (deregister_votes.size() == quorum.size())
+      {
+        cryptonote::tx_extra_service_node_deregister deregister;
+        deregister.block_height       = new_vote.block_height;
+        deregister.service_node_index = new_vote.service_node_index;
+        deregister.votes.reserve(deregister_votes.size());
+
+        for (const auto& entry : deregister_votes)
+        {
+          cryptonote::tx_extra_service_node_deregister::vote tx_vote = {};
+          tx_vote.signature           = *reinterpret_cast<const cryptonote::tx_extra_service_node_deregister::signature_pod *>(&new_vote.signature);
+          tx_vote.voters_quorum_index = new_vote.voters_quorum_index;
+          deregister.votes.push_back(tx_vote);
+        }
+
+        vvc.m_full_tx_deregister_made = true;
+        tx.version = cryptonote::transaction::version_3_deregister_tx;
+        cryptonote::add_service_node_deregister_to_tx_extra(tx.extra, deregister);
+      }
+    }
+
+    return true;
+  }
+}; // namespace loki

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -103,7 +103,10 @@ namespace loki
       class pool_entry
       {
         public:
-          pool_entry(service_node_deregister::vote vote) : m_vote(vote) {}
+          pool_entry(uint64_t time_last_sent_p2p, service_node_deregister::vote vote)
+            : m_time_last_sent_p2p(time_last_sent_p2p), m_vote(vote) {}
+
+          uint64_t m_time_last_sent_p2p;
           service_node_deregister::vote m_vote;
       };
 
@@ -120,7 +123,12 @@ namespace loki
        */
       bool add_vote(const service_node_deregister::vote& new_vote, cryptonote::vote_verification_context& vvc,
                     const std::vector<crypto::public_key>& quorum, cryptonote::transaction &tx);
+
+      // TODO(doyle): Review relay behaviour and all the cases when it should be triggered
       void xx__print_service_node() const;
+      void set_relayed           (const std::vector<service_node_deregister::vote>& votes);
+      void remove_expired_votes  (uint64_t height);
+      std::vector<service_node_deregister::vote> get_relayable_votes() const;
 
     private:
       std::vector<pool_group> m_deregisters;

--- a/src/cryptonote_core/service_node_deregister.h
+++ b/src/cryptonote_core/service_node_deregister.h
@@ -1,0 +1,130 @@
+// Copyright (c) 2018, The Loki Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+
+#include "crypto/crypto.h"
+#include "cryptonote_basic/cryptonote_basic.h"
+
+#include "math_helper.h"
+#include "syncobj.h"
+
+namespace cryptonote
+{
+  struct vote_verification_context;
+  class Blockchain;
+};
+
+namespace loki
+{
+  // TODO(doyle): Complexity analysis for managing votes, determine the upper
+  // and lower bounds of what numbers we expect.
+
+  // std::vector<Block Height Entries> partial_deregisters
+  // My assumption is that the block heights we keep votes around for
+  // is going to be very small and short lived < 10 entries ~ 20mins worth of
+  // blocks, avg block time 120s. So linearly scanning for a block height is
+  // effective with low code complexity/computation and memory usage.
+
+  // std::unordered_map<Node Index, std::Vector<Votes>> service_node_votes
+  // In each block height we have our quorum 10 SNodes querying 1% of the
+  // network. Assuming a very generous 50,000 node network, 1% of nodes is 500,
+  // with each needing 10 votes to kick off the network, so 500 entries in the
+  // map with 10 votes each.
+  // As opposed to (500 nodes * 10 votes) = 5000 votes to sort and search if in
+  // a vector per block height.
+
+  namespace xx__service_node
+  {
+    extern const char *secret_spend_keys_str[100];
+    extern const char *secret_view_keys_str[100];
+    extern const char *public_spend_keys_str[100];
+    extern const char *public_view_keys_str[100];
+    extern std::vector<crypto::secret_key> secret_view_keys;
+    extern std::vector<crypto::public_key> public_view_keys;
+    extern std::vector<crypto::secret_key> secret_spend_keys;
+    extern std::vector<crypto::public_key> public_spend_keys;
+    void init();
+  };
+
+  namespace service_node_deregister
+  {
+    struct vote
+    {
+      uint64_t          block_height;
+      uint32_t          service_node_index;
+      uint32_t          voters_quorum_index;
+      crypto::signature signature;
+    };
+
+    crypto::hash make_unsigned_vote_hash(const cryptonote::tx_extra_service_node_deregister& deregister);
+    crypto::hash make_unsigned_vote_hash(const vote& v);
+
+    bool verify(const cryptonote::tx_extra_service_node_deregister& deregister,
+                cryptonote::vote_verification_context& vvc,
+                const std::vector<crypto::public_key> &quorum);
+
+    bool verify(const vote& v, cryptonote::vote_verification_context &vvc,
+                const std::vector<crypto::public_key> &quorum);
+  };
+
+  // TODO(doyle): We need to a scheme to remove dead votes, see tx_memory_pool::on_idle
+  class deregister_vote_pool
+  {
+    public:
+      class pool_entry
+      {
+        public:
+          pool_entry(service_node_deregister::vote vote) : m_vote(vote) {}
+          service_node_deregister::vote m_vote;
+      };
+
+      struct pool_group
+      {
+        using service_node_index = uint32_t;
+        uint64_t block_height;
+        time_t   time_group_created;
+        std::unordered_map<service_node_index, std::vector<pool_entry>> service_node;
+      };
+
+      /**
+       *  @return True if vote was valid and in the pool already or just added (check vote verfication for specific case).
+       */
+      bool add_vote(const service_node_deregister::vote& new_vote, cryptonote::vote_verification_context& vvc,
+                    const std::vector<crypto::public_key>& quorum, cryptonote::transaction &tx);
+      void xx__print_service_node() const;
+
+    private:
+      std::vector<pool_group> m_deregisters;
+      mutable epee::critical_section m_lock;
+  };
+
+}; // namespace loki

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -34,6 +34,8 @@
 #include "serialization/keyvalue_serialization.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/blobdatatype.h"
+#include "cryptonote_core/service_node_deregister.h"
+
 namespace cryptonote
 {
 
@@ -280,5 +282,21 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   }; 
+
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct NOTIFY_NEW_DEREGISTER_VOTE
+  {
+    const static int ID = BC_COMMANDS_POOL_BASE + 10;
+
+    struct request
+    {
+      std::vector<loki::service_node_deregister::vote> votes;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(votes)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
     
 }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -36,6 +36,7 @@
 
 #include <boost/program_options/variables_map.hpp>
 #include <string>
+#include <unordered_map>
 
 #include "math_helper.h"
 #include "storages/levin_abstract_invoke2.h"
@@ -90,6 +91,7 @@ namespace cryptonote
       HANDLE_NOTIFY_T2(NOTIFY_RESPONSE_CHAIN_ENTRY, &cryptonote_protocol_handler::handle_response_chain_entry)
       HANDLE_NOTIFY_T2(NOTIFY_NEW_FLUFFY_BLOCK, &cryptonote_protocol_handler::handle_notify_new_fluffy_block)			
       HANDLE_NOTIFY_T2(NOTIFY_REQUEST_FLUFFY_MISSING_TX, &cryptonote_protocol_handler::handle_request_fluffy_missing_tx)						
+      HANDLE_NOTIFY_T2(NOTIFY_NEW_DEREGISTER_VOTE, &cryptonote_protocol_handler::handle_notify_new_deregister_vote)						
     END_INVOKE_MAP2()
 
     bool on_idle();
@@ -119,10 +121,12 @@ namespace cryptonote
     int handle_response_chain_entry(int command, NOTIFY_RESPONSE_CHAIN_ENTRY::request& arg, cryptonote_connection_context& context);
     int handle_notify_new_fluffy_block(int command, NOTIFY_NEW_FLUFFY_BLOCK::request& arg, cryptonote_connection_context& context);
     int handle_request_fluffy_missing_tx(int command, NOTIFY_REQUEST_FLUFFY_MISSING_TX::request& arg, cryptonote_connection_context& context);
+    int handle_notify_new_deregister_vote(int command, NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& context);
 		
     //----------------- i_bc_protocol_layout ---------------------------------------
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context);
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context);
+    virtual bool relay_deregister_vote(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context);
     //----------------------------------------------------------------------------------
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);
     bool request_missing_objects(cryptonote_connection_context& context, bool check_having_blocks, bool force_next_span = false);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler_common.h
@@ -43,6 +43,7 @@ namespace cryptonote
     virtual bool relay_block(NOTIFY_NEW_BLOCK::request& arg, cryptonote_connection_context& exclude_context)=0;
     virtual bool relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context)=0;
     //virtual bool request_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, cryptonote_connection_context& context)=0;
+    virtual bool relay_deregister_vote(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)=0;
   };
 
   /************************************************************************/
@@ -58,6 +59,9 @@ namespace cryptonote
     {
       return false;
     }
-
+    virtual bool relay_deregister_vote(NOTIFY_NEW_DEREGISTER_VOTE::request& arg, cryptonote_connection_context& exclude_context)
+    {
+      return false;
+    }
   };
 }

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -125,6 +125,25 @@ bool t_command_parser_executor::print_blockchain_info(const std::vector<std::str
   return m_executor.print_blockchain_info(start_index, end_index);
 }
 
+bool t_command_parser_executor::print_quorum_list(const std::vector<std::string>& args)
+{
+  if(args.size() != 1)
+  {
+    std::cout << "need block height parameter" << std::endl;
+    return false;
+  }
+
+  uint64_t height = 0;
+  if(!epee::string_tools::get_xtype_from_string(height, args[0]))
+  {
+    std::cout << "wrong block height parameter" << std::endl;
+    return false;
+  }
+
+  return m_executor.print_quorum_list(height);
+}
+
+
 bool t_command_parser_executor::set_log_level(const std::vector<std::string>& args)
 {
   if(args.size() > 1)

--- a/src/daemon/command_parser_executor.h
+++ b/src/daemon/command_parser_executor.h
@@ -75,6 +75,8 @@ public:
 
   bool print_blockchain_info(const std::vector<std::string>& args);
 
+  bool print_quorum_list(const std::vector<std::string>& args);
+
   bool set_log_level(const std::vector<std::string>& args);
 
   bool set_log_categories(const std::vector<std::string>& args);

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -96,6 +96,12 @@ t_command_server::t_command_server(
     , "Print a given transaction."
     );
   m_command_lookup.set_handler(
+      "print_quorum_list"
+    , std::bind(&t_command_parser_executor::print_quorum_list, &m_parser, p::_1)
+    , "print_quorum_list <height>"
+    , "Print the quorum list for the block height."
+    );
+  m_command_lookup.set_handler(
       "is_key_image_spent"
     , std::bind(&t_command_parser_executor::is_key_image_spent, &m_parser, p::_1)
     , "is_key_image_spent <key_image>"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -567,6 +567,41 @@ bool t_rpc_command_executor::print_blockchain_info(uint64_t start_block_index, u
   return true;
 }
 
+bool t_rpc_command_executor::print_quorum_list(uint64_t height)
+{
+  cryptonote::COMMAND_RPC_GET_QUORUM_LIST::request req;
+  cryptonote::COMMAND_RPC_GET_QUORUM_LIST::response res;
+  epee::json_rpc::error error_resp;
+
+  req.height = height;
+  std::string fail_message = "Unsuccessful";
+
+  if (m_is_rpc)
+  {
+    if (!m_rpc_client->json_rpc_request(req, res, "get_quorum_list", fail_message.c_str()))
+    {
+      return true;
+    }
+  }
+  else
+  {
+    if (!m_rpc_server->on_get_quorum_list_json(req, res, error_resp) || res.status != CORE_RPC_STATUS_OK)
+    {
+      tools::fail_msg_writer() << make_error(fail_message, res.status);
+      return true;
+    }
+  }
+
+  for (size_t i = 0; i < res.quorum.size(); i++)
+  {
+    const std::string &entry = res.quorum[i];
+    tools::msg_writer() << "[" << i << "] " << entry;
+  }
+
+  return true;
+}
+
+
 bool t_rpc_command_executor::set_log_level(int8_t level) {
   cryptonote::COMMAND_RPC_SET_LOG_LEVEL::request req;
   cryptonote::COMMAND_RPC_SET_LOG_LEVEL::response res;

--- a/src/daemon/rpc_command_executor.h
+++ b/src/daemon/rpc_command_executor.h
@@ -86,6 +86,8 @@ public:
 
   bool print_blockchain_info(uint64_t start_block_index, uint64_t end_block_index);
 
+  bool print_quorum_list(uint64_t height);
+
   bool set_log_level(int8_t level);
 
   bool set_log_categories(const std::string &categories);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -121,6 +121,7 @@ namespace cryptonote
       MAP_URI_AUTO_JON2("/get_outs", on_get_outs, COMMAND_RPC_GET_OUTPUTS)      
       MAP_URI_AUTO_JON2_IF("/update", on_update, COMMAND_RPC_UPDATE, !m_restricted)
       MAP_URI_AUTO_JON2("/get_quorum_list", on_get_quorum_list, COMMAND_RPC_GET_QUORUM_LIST)
+      MAP_URI_AUTO_JON2("/submit_deregister_vote", on_submit_deregister_vote, COMMAND_RPC_SEND_DEREGISTER_VOTE)
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC("get_block_count",           on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
         MAP_JON_RPC("getblockcount",             on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
@@ -193,7 +194,8 @@ namespace cryptonote
     bool on_stop_save_graph(const COMMAND_RPC_STOP_SAVE_GRAPH::request& req, COMMAND_RPC_STOP_SAVE_GRAPH::response& res);
     bool on_update(const COMMAND_RPC_UPDATE::request& req, COMMAND_RPC_UPDATE::response& res);
     bool on_get_quorum_list(const COMMAND_RPC_GET_QUORUM_LIST::request& req, COMMAND_RPC_GET_QUORUM_LIST::response& res);
-    
+    bool on_submit_deregister_vote(const COMMAND_RPC_SEND_DEREGISTER_VOTE::request& req, COMMAND_RPC_SEND_DEREGISTER_VOTE::response& resp);
+
     //json_rpc
     bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);
     bool on_getblockhash(const COMMAND_RPC_GETBLOCKHASH::request& req, COMMAND_RPC_GETBLOCKHASH::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -120,6 +120,7 @@ namespace cryptonote
       MAP_URI_AUTO_JON2_IF("/stop_save_graph", on_stop_save_graph, COMMAND_RPC_STOP_SAVE_GRAPH, !m_restricted)
       MAP_URI_AUTO_JON2("/get_outs", on_get_outs, COMMAND_RPC_GET_OUTPUTS)      
       MAP_URI_AUTO_JON2_IF("/update", on_update, COMMAND_RPC_UPDATE, !m_restricted)
+      MAP_URI_AUTO_JON2("/get_quorum_list", on_get_quorum_list, COMMAND_RPC_GET_QUORUM_LIST)
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC("get_block_count",           on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
         MAP_JON_RPC("getblockcount",             on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
@@ -154,6 +155,7 @@ namespace cryptonote
         MAP_JON_RPC_WE_IF("sync_info",           on_sync_info,                  COMMAND_RPC_SYNC_INFO, !m_restricted)
         MAP_JON_RPC_WE("get_txpool_backlog",     on_get_txpool_backlog,         COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG)
         MAP_JON_RPC_WE("get_output_distribution", on_get_output_distribution, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION)
+        MAP_JON_RPC_WE("get_quorum_list",         on_get_quorum_list_json,      COMMAND_RPC_GET_QUORUM_LIST)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 
@@ -190,6 +192,7 @@ namespace cryptonote
     bool on_start_save_graph(const COMMAND_RPC_START_SAVE_GRAPH::request& req, COMMAND_RPC_START_SAVE_GRAPH::response& res);
     bool on_stop_save_graph(const COMMAND_RPC_STOP_SAVE_GRAPH::request& req, COMMAND_RPC_STOP_SAVE_GRAPH::response& res);
     bool on_update(const COMMAND_RPC_UPDATE::request& req, COMMAND_RPC_UPDATE::response& res);
+    bool on_get_quorum_list(const COMMAND_RPC_GET_QUORUM_LIST::request& req, COMMAND_RPC_GET_QUORUM_LIST::response& res);
     
     //json_rpc
     bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);
@@ -216,6 +219,7 @@ namespace cryptonote
     bool on_sync_info(const COMMAND_RPC_SYNC_INFO::request& req, COMMAND_RPC_SYNC_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_get_txpool_backlog(const COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::request& req, COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG::response& res, epee::json_rpc::error& error_resp);
     bool on_get_output_distribution(const COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::request& req, COMMAND_RPC_GET_OUTPUT_DISTRIBUTION::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_quorum_list_json(const COMMAND_RPC_GET_QUORUM_LIST::request& req, COMMAND_RPC_GET_QUORUM_LIST::response& res, epee::json_rpc::error& error_resp);
     //-----------------------
 
 private:

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -31,8 +31,10 @@
 #pragma once
 #include "cryptonote_protocol/cryptonote_protocol_defs.h"
 #include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/verification_context.h"
 #include "cryptonote_basic/difficulty.h"
 #include "crypto/hash.h"
+#include "cryptonote_core/service_node_deregister.h"
 
 namespace cryptonote
 {
@@ -49,7 +51,7 @@ namespace cryptonote
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 1
-#define CORE_RPC_VERSION_MINOR 20
+#define CORE_RPC_VERSION_MINOR 1
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -2286,4 +2288,37 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
+
+  struct COMMAND_RPC_SEND_DEREGISTER_VOTE
+  {
+      struct request
+      {
+        loki::service_node_deregister::vote vote;
+
+        BEGIN_KV_SERIALIZE_MAP()
+          KV_SERIALIZE_VAL_POD_AS_BLOB(vote)
+        END_KV_SERIALIZE_MAP()
+      };
+
+      struct response
+      {
+        std::string status;
+        std::string reason;
+
+        bool invalid_block_height;
+        bool voters_quorum_index_out_of_bounds;
+        bool service_node_index_out_of_bounds;
+        bool signature_not_valid;
+
+        BEGIN_KV_SERIALIZE_MAP()
+          KV_SERIALIZE(status)
+          KV_SERIALIZE(reason)
+          KV_SERIALIZE(invalid_block_height)
+          KV_SERIALIZE(voters_quorum_index_out_of_bounds)
+          KV_SERIALIZE(service_node_index_out_of_bounds)
+          KV_SERIALIZE(signature_not_valid)
+        END_KV_SERIALIZE_MAP()
+      };
+  };
+
 }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2263,4 +2263,27 @@ namespace cryptonote
     };
   };
 
+  struct COMMAND_RPC_GET_QUORUM_LIST
+  {
+    struct request
+    {
+      uint64_t height;
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(height)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      std::string status;
+      std::vector<std::string> quorum;
+      bool untrusted;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(quorum)
+        KV_SERIALIZE(untrusted)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -52,6 +52,7 @@
 #include "common/base58.h"
 #include "common/scoped_message_writer.h"
 #include "cryptonote_protocol/cryptonote_protocol_handler.h"
+#include "cryptonote_core/service_node_deregister.h"
 #include "simplewallet.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "storages/http_abstract_invoke.h"
@@ -2019,6 +2020,14 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::locked_sweep_all, this, _1),
                            tr("locked_sweep_all [index=<N1>[,<N2>,...]] [<priority>] <address> <lockblocks> [<payment_id>]"),
                            tr("Send all unlocked balance to an address and lock it for <lockblocks> (max. 1000000). If the parameter \"index<N1>[,<N2>,...]\" is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used."));
+  m_cmd_binder.set_handler("xx__deregister_service_node",
+                           boost::bind(&simple_wallet::xx__deregister_service_node, this, _1),
+                           tr("xx__deregister_service_node [partial] <node id>"),
+                           tr("Submit a deregistration transaction for the given node id."));
+  m_cmd_binder.set_handler("xx__get_quorum",
+                           boost::bind(&simple_wallet::xx__get_quorum, this, _1),
+                           tr("xx__get_quorum <block height>"),
+                           tr("Get the quorum for the given height"));
   m_cmd_binder.set_handler("sweep_unmixable",
                            boost::bind(&simple_wallet::sweep_unmixable, this, _1),
                            tr("Deprecated"));
@@ -4661,7 +4670,203 @@ bool simple_wallet::locked_sweep_all(const std::vector<std::string> &args_)
   return sweep_main(0, true, args_);
 }
 //----------------------------------------------------------------------------------------------------
+bool simple_wallet::xx__deregister_service_node(const std::vector<std::string> &args_)
+{
+  // TODO: This should be an internal function that the wallet rpc can invoke
+  // autonomously and make partial votes as the state of the blockchain changes.
+  // So we need to register as an RPC call.
 
+  // xx__deregister_node [partial] <node id>
+  if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
+  if (!try_connect_to_daemon())
+    return true;
+
+  tools::wallet2::pending_tx ptx;
+  ptx.tx.unlock_time = 0;
+
+  int num_votes                       = 10;
+  int service_node_key_str_arg_index  = 0;
+  bool is_partial_cmd = false;
+
+  if (args_.size() == 1)
+  {
+    ptx.tx.version = transaction::version_3_deregister_tx;
+  }
+  else if (args_.size() == 2)
+  {
+    is_partial_cmd = true;
+    service_node_key_str_arg_index = 1;
+    num_votes = 1;
+  }
+  else
+  {
+    fail_msg_writer() << "expected 1 or 2 arguments, received: " << args_.size();
+    return true;
+  }
+
+  loki::xx__service_node::init();
+  tx_extra_service_node_deregister deregister = {};
+  deregister.votes.resize(num_votes);
+  {
+    std::vector<uint8_t> &extra = ptx.tx.extra;
+    {
+      std::string err;
+      uint64_t bc_height = std::max((get_daemon_blockchain_height(err) - 5 /*Always use 5 blocks back*/), (uint64_t)0);
+      if (!err.empty())
+      {
+        fail_msg_writer() << tr("failed to get blockchain height: ") << err;
+        return true;
+      }
+      /* deregister.block_height = bc_height; */
+      deregister.block_height = 20;
+    }
+
+    const std::string& service_node_key_str = args_[service_node_key_str_arg_index];
+    crypto::public_key service_node_key = {};
+    {
+      if (!epee::string_tools::hex_to_pod(service_node_key_str, service_node_key))
+      {
+        fail_msg_writer() << tr("failed to parse service node key: ") << service_node_key_str;
+        return true;
+      }
+    }
+
+    // Get the index of this service node in the quorum
+    {
+      COMMAND_RPC_GET_QUORUM_LIST::request req = AUTO_VAL_INIT(req);
+      COMMAND_RPC_GET_QUORUM_LIST::response res;
+      req.height = 32;
+
+      bool r = m_wallet->invoke_http_json("/get_quorum_list", req, res);
+      const std::string err = interpret_rpc_response(r, res.status);
+
+      if (!err.empty())
+      {
+        fail_msg_writer() << tr("Failed to retrieve quorum: ") << err;
+        return true;
+      }
+
+      for (int i = 0; i < num_votes; i++)
+      {
+        bool found_my_service_node_in_quorum = false;
+        const std::string this_service_node_key = loki::xx__service_node::public_spend_keys_str[i];
+
+        for (size_t j = 0; j < res.quorum.size(); j++)
+        {
+          const std::string &entry_str = res.quorum[j];
+          if (entry_str == this_service_node_key)
+          {
+            deregister.votes[i].voters_quorum_index = i;
+            found_my_service_node_in_quorum = true;
+            break;
+          }
+        }
+
+        if (!found_my_service_node_in_quorum)
+        {
+          fail_msg_writer() << tr("Failed to find service node in quorum: ") << service_node_key;
+          return true;
+        }
+      }
+    }
+
+
+    // Generate signatures
+    srand(time(NULL));
+    for (int i = 0; i < num_votes; i++)
+    {
+      size_t index = rand() % 10;
+      const crypto::public_key &public_spend_key = loki::xx__service_node::public_spend_keys[index];
+      const crypto::secret_key &secret_spend_key = loki::xx__service_node::secret_spend_keys[index];
+
+      tx_extra_service_node_deregister::vote *vote = &deregister.votes[i];
+      vote->voters_quorum_index = index;
+
+      crypto::hash hash = loki::service_node_deregister::make_unsigned_vote_hash(deregister);
+      auto *signature = reinterpret_cast<crypto::signature *>(&vote->signature);
+      crypto::generate_signature(hash, public_spend_key, secret_spend_key, *signature);
+    }
+
+  }
+
+  if (is_partial_cmd)
+  {
+    for (int i = 0; i < num_votes; i++)
+    {
+      loki::service_node_deregister::vote vote = {};
+      vote.block_height                        = deregister.block_height;
+      vote.service_node_index                  = deregister.service_node_index;
+      vote.voters_quorum_index                 = deregister.votes[i].voters_quorum_index;
+      vote.signature                           = *reinterpret_cast<crypto::signature *>(&deregister.votes[i].signature);
+
+      try
+      {
+        m_wallet->commit_deregister_vote(vote);
+      }
+      catch (const std::exception &e)
+      {
+        handle_transfer_exception(std::current_exception(), is_daemon_trusted());
+      }
+    }
+  }
+  else
+  {
+    add_service_node_deregister_to_tx_extra(ptx.tx.extra, deregister);
+    try
+    {
+      m_wallet->commit_tx(ptx);
+    }
+    catch (const std::exception &e)
+    {
+      handle_transfer_exception(std::current_exception(), is_daemon_trusted());
+    }
+  }
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::xx__get_quorum(const std::vector<std::string> &args_)
+{
+  // xx__get_quorum <block height>
+  if (!try_connect_to_daemon())
+    return true;
+
+  const int expect_num_args = 1;
+  if (args_.size() != expect_num_args)
+  {
+    fail_msg_writer() << tr("expected 1 argument (block height) received: ") << args_.size();
+    return true;
+  }
+
+  COMMAND_RPC_GET_QUORUM_LIST::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_QUORUM_LIST::response res;
+  try
+  {
+      req.height = boost::lexical_cast<uint64_t>(args_[0]);
+  }
+  catch(const boost::bad_lexical_cast &)
+  {
+    fail_msg_writer() << tr("bad block height parameter: ") << args_[0];
+    return true;
+  }
+
+  bool r = m_wallet->invoke_http_json("/get_quorum_list", req, res);
+  const std::string err = interpret_rpc_response(r, res.status);
+  if (err.empty())
+  {
+    for (size_t i = 0; i < res.quorum.size(); i++)
+    {
+      const std::string &entry = res.quorum[i];
+      message_writer() << "[" << i << "] " << entry;
+    }
+  }
+  else
+  {
+    fail_msg_writer() << tr("Failed to retrieve quorum: ") << err;
+  }
+
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
 bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
 {
   if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -154,6 +154,9 @@ namespace cryptonote
     bool transfer_new(const std::vector<std::string> &args);
     bool locked_transfer(const std::vector<std::string> &args);
     bool locked_sweep_all(const std::vector<std::string> &args);
+    bool stake_all(const std::vector<std::string> &args);
+    bool xx__deregister_service_node(const std::vector<std::string> &args);
+    bool xx__get_quorum(const std::vector<std::string> &args);
     bool sweep_main(uint64_t below, bool locked, const std::vector<std::string> &args);
     bool sweep_all(const std::vector<std::string> &args);
     bool sweep_below(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4581,7 +4581,29 @@ crypto::hash wallet2::get_payment_id(const pending_tx &ptx) const
   }
   return payment_id;
 }
+//----------------------------------------------------------------------------------------------------
+void wallet2::commit_deregister_vote(loki::service_node_deregister::vote& vote)
+{
+  if (m_light_wallet)
+  {
+    LOG_PRINT_L1("Deregister vote can not be sent in a light wallet.");
+  }
+  else
+  {
+    COMMAND_RPC_SEND_DEREGISTER_VOTE::request req;
+    req.vote = vote;
 
+    COMMAND_RPC_SEND_DEREGISTER_VOTE::response resp;
+
+    m_daemon_rpc_mutex.lock();
+    bool r = epee::net_utils::invoke_http_json("/submit_deregister_vote", req, resp, m_http_client, rpc_timeout);
+    m_daemon_rpc_mutex.unlock();
+
+    THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "submit_deregister_vote");
+    THROW_WALLET_EXCEPTION_IF(resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "submit_deregister_vote");
+    THROW_WALLET_EXCEPTION_IF(resp.status != CORE_RPC_STATUS_OK, error::vote_rejected, resp.status, resp.reason);
+  }
+}
 //----------------------------------------------------------------------------------------------------
 // take a pending tx and actually send it to the daemon
 void wallet2::commit_tx(pending_tx& ptx)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -44,6 +44,7 @@
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/account_boost_serialization.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
+#include "cryptonote_core/service_node_deregister.h"
 #include "net/http_client.h"
 #include "storages/http_abstract_invoke.h"
 #include "rpc/core_rpc_server_commands_defs.h"
@@ -683,6 +684,7 @@ namespace tools
       std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs,
       uint64_t unlock_time, uint64_t fee, const std::vector<uint8_t>& extra, cryptonote::transaction& tx, pending_tx &ptx, bool bulletproof);
 
+    void commit_deregister_vote(loki::service_node_deregister::vote& vote);
     void commit_tx(pending_tx& ptx_vector);
     void commit_tx(std::vector<pending_tx>& ptx_vector);
     bool save_tx(const std::vector<pending_tx>& ptx_vector, const std::string &filename) const;

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -77,6 +77,7 @@ namespace tools
     //         tx_not_possible
     //         not_enough_outs_to_mix
     //         tx_not_constructed
+    //         vote_rejected
     //         tx_rejected
     //         tx_sum_overflow
     //         tx_too_big
@@ -616,6 +617,34 @@ namespace tools
 
     private:
       cryptonote::transaction m_tx;
+      std::string m_status;
+      std::string m_reason;
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct vote_rejected : public transfer_error
+    {
+      explicit vote_rejected(std::string&& loc, const std::string& status, const std::string& reason)
+        : transfer_error(std::move(loc), "vote was rejected by daemon")
+        , m_status(status)
+        , m_reason(reason)
+      {
+      }
+
+      const std::string& status() const { return m_status; }
+      const std::string& reason() const { return m_reason; }
+
+      std::string to_string() const
+      {
+        std::ostringstream ss;
+        ss << transfer_error::to_string() << ", status = " << m_status;
+        if (!m_reason.empty())
+        {
+          ss << " (" << m_reason << ")";
+        }
+        return ss.str();
+      }
+
+    private:
       std::string m_status;
       std::string m_reason;
     };

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -32,6 +32,7 @@
 
 #include <boost/program_options/variables_map.hpp>
 
+#include "cryptonote_core/service_node_deregister.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_basic/verification_context.h"
 #include <unordered_map>
@@ -103,5 +104,8 @@ namespace tests
     cryptonote::difficulty_type get_block_cumulative_difficulty(uint64_t height) const { return 0; }
     bool fluffy_blocks_enabled() const { return false; }
     uint64_t prevalidate_block_hashes(uint64_t height, const std::list<crypto::hash> &hashes) { return 0; }
+
+    // TODO(loki): Write tests
+    bool add_deregister_vote(const loki::service_node_deregister::vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
   };
 }

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -32,9 +32,9 @@
 
 #include <boost/program_options/variables_map.hpp>
 
-#include "cryptonote_core/service_node_deregister.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_basic/verification_context.h"
+#include "cryptonote_core/service_node_deregister.h"
 #include <unordered_map>
 
 namespace tests
@@ -106,6 +106,7 @@ namespace tests
     uint64_t prevalidate_block_hashes(uint64_t height, const std::list<crypto::hash> &hashes) { return 0; }
 
     // TODO(loki): Write tests
+    virtual void set_deregister_vote_relayed(const std::vector<loki::service_node_deregister::vote>& votes) {}
     bool add_deregister_vote(const loki::service_node_deregister::vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
   };
 }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -83,6 +83,9 @@ public:
   bool fluffy_blocks_enabled() const { return false; }
   uint64_t prevalidate_block_hashes(uint64_t height, const std::list<crypto::hash> &hashes) { return 0; }
   void stop() {}
+
+  // TODO(loki): Write testst
+  bool add_deregister_vote(const loki::service_node_deregister::vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
 };
 
 typedef nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<test_core>> Server;

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -84,8 +84,9 @@ public:
   uint64_t prevalidate_block_hashes(uint64_t height, const std::list<crypto::hash> &hashes) { return 0; }
   void stop() {}
 
-  // TODO(loki): Write testst
-  bool add_deregister_vote(const loki::service_node_deregister::vote& vote, cryptonote::vote_verification_context &vvc) { return false; }
+  // TODO(loki): Write tests
+  bool add_deregister_vote(const loki::service_node_deregister::vote& vote, cryptonote::vote_verification_context &vvc) { return true; }
+  virtual void set_deregister_vote_relayed(const std::vector<loki::service_node_deregister::vote>& votes) {}
 };
 
 typedef nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<test_core>> Server;


### PR DESCRIPTION
Internal review so I can get some feedback and get some of these TODOs addressed. This will be the first of probably a few reviews before being reviewed on dev because a lot of "temporary" code is still present in the commits.

I squashed all my commits and resplit them out into parts abit to help comprehension. I put deregister and partial deregister implementations into 1 commit because splitting the two proved to be abit difficult.

Any code that is prefixed with xx__* is generally temporary code and will be deleted before production.

The main flow to follow the code paths are, 
1. simplewallet::xx__deregister_service_node(): Make a partial or full deregistration cmd
2.a. wallet2::commit_tx(): To send the full deregistration to daemon RPC
3.a. core_rpc_server::on_send_raw_tx(): Submit full TX to core for validation
... And so forth, this follows the same code path as regular TX's.

2.b. wallet2::commit_deregister_vote(): To send a partial deregistration vote to daemon RPC
3.b. core_rpc_server::on_submit_deregister_vote(): Submit vote to core for validation
4.b. core::add_deregister_vote(): Passes vote down to vote pool
5.b. loki::deregister_vote_pool::add_vote(): Validate the given vote, add it to the pool

From here, if the vote was valid all votes are collected, the full deregistration is constructed in 3b.