### PR TITLE
Loki Name System - Name Hashing/Mapping Value Encryption/Decryption

### DIFF
--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -387,15 +387,15 @@ namespace cryptonote
     uint8_t                    version = 0;
     crypto::ed25519_public_key owner;
     uint16_t                   type;
-    std::string                name;
+    crypto::hash               name_hash;
     std::string                value; // binary format of the name->value mapping
     crypto::hash               prev_txid = crypto::null_hash; // previous txid that purchased the mapping
 
     tx_extra_loki_name_system() = default;
-    tx_extra_loki_name_system(crypto::ed25519_public_key const &owner, uint16_t type, std::string const &name, std::string const &value, crypto::hash const &prev_txid)
+    tx_extra_loki_name_system(crypto::ed25519_public_key const &owner, uint16_t type, crypto::hash const &name_hash, std::string const &value, crypto::hash const &prev_txid)
     : owner(owner)
     , type(type)
-    , name(name)
+    , name_hash(name_hash)
     , value(value)
     , prev_txid(prev_txid)
     {
@@ -405,7 +405,7 @@ namespace cryptonote
       FIELD(version);
       FIELD(owner);
       FIELD(type);
-      FIELD(name);
+      FIELD(name_hash);
       FIELD(value);
       FIELD(prev_txid);
     END_SERIALIZE()

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -388,15 +388,15 @@ namespace cryptonote
     crypto::ed25519_public_key owner;
     uint16_t                   type;
     crypto::hash               name_hash;
-    std::string                value; // binary format of the name->value mapping
+    std::string                encrypted_value; // encrypted binary format of the value in the name->value mapping
     crypto::hash               prev_txid = crypto::null_hash; // previous txid that purchased the mapping
 
     tx_extra_loki_name_system() = default;
-    tx_extra_loki_name_system(crypto::ed25519_public_key const &owner, uint16_t type, crypto::hash const &name_hash, std::string const &value, crypto::hash const &prev_txid)
+    tx_extra_loki_name_system(crypto::ed25519_public_key const &owner, uint16_t type, crypto::hash const &name_hash, std::string const &encrypted_value, crypto::hash const &prev_txid)
     : owner(owner)
     , type(type)
     , name_hash(name_hash)
-    , value(value)
+    , encrypted_value(encrypted_value)
     , prev_txid(prev_txid)
     {
     }
@@ -406,7 +406,7 @@ namespace cryptonote
       FIELD(owner);
       FIELD(type);
       FIELD(name_hash);
-      FIELD(value);
+      FIELD(encrypted_value);
       FIELD(prev_txid);
     END_SERIALIZE()
   };

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -59,7 +59,7 @@ enum struct mapping_record_row
   id,
   type,
   name_hash,
-  value,
+  encrypted_value,
   txid,
   prev_txid,
   register_height,
@@ -134,9 +134,18 @@ static bool sql_run_statement(cryptonote::network_type nettype, lns_sql_type typ
             tmp_entry.register_height = static_cast<uint16_t>(sqlite3_column_int(statement, static_cast<int>(mapping_record_row::register_height)));
             tmp_entry.owner_id = sqlite3_column_int(statement, static_cast<int>(mapping_record_row::owner_id));
 
-            size_t value_len = static_cast<size_t>(sqlite3_column_bytes(statement, static_cast<int>(mapping_record_row::value)));
-            auto *value      = reinterpret_cast<char const *>(sqlite3_column_text(statement, static_cast<int>(mapping_record_row::value)));
-            tmp_entry.value = std::string(value, value_len);
+            // Copy encrypted_value
+            {
+              size_t value_len = static_cast<size_t>(sqlite3_column_bytes(statement, static_cast<int>(mapping_record_row::encrypted_value)));
+              auto *value      = reinterpret_cast<char const *>(sqlite3_column_text(statement, static_cast<int>(mapping_record_row::encrypted_value)));
+              if (value_len > tmp_entry.encrypted_value.buffer.size())
+              {
+                  MERROR("Unexpected encrypted value blob with size=" << value_len << ", in LNS db larger than the available size=" << tmp_entry.encrypted_value.buffer.size());
+                  return false;
+              }
+              tmp_entry.encrypted_value.len = value_len;
+              memcpy(&tmp_entry.encrypted_value.buffer[0], value, value_len);
+            }
 
             if (!sql_copy_blob(statement, static_cast<int>(mapping_record_row::name_hash), tmp_entry.name_hash.data, sizeof(tmp_entry.name_hash)))
               return false;
@@ -400,7 +409,7 @@ static bool check_lengths(uint16_t type, std::string const &value, size_t max, s
     if (reason)
     {
       std::stringstream err_stream;
-      err_stream << "LNS type=" << type << ", specifies mapping from name_hash->value where the value's length=" << value.size() << ", does not equal the required length=" << max << ", given value=" << value;
+      err_stream << "LNS type=" << type << ", specifies mapping from name_hash->encrypted_value where the value's length=" << value.size() << ", does not equal the required length=" << max << ", given value=" << value;
       *reason = err_stream.str();
     }
   }
@@ -408,16 +417,16 @@ static bool check_lengths(uint16_t type, std::string const &value, size_t max, s
   return result;
 }
 
-bool validate_lns_value(cryptonote::network_type nettype, uint16_t type, std::string const &value, lns_value *blob, std::string *reason)
+bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std::string const &value, mapping_value *blob, std::string *reason)
 {
   if (blob) *blob = {};
   std::stringstream err_stream;
 
   cryptonote::address_parse_info addr_info = {};
 
-  static_assert(lns_value::BUFFER_SIZE >= SESSION_PUBLIC_KEY_BINARY_LENGTH, "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
-  static_assert(lns_value::BUFFER_SIZE >= LOKINET_ADDRESS_BINARY_LENGTH,    "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
-  static_assert(lns_value::BUFFER_SIZE >= sizeof(addr_info.address),        "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
+  static_assert(mapping_value::BUFFER_SIZE >= SESSION_PUBLIC_KEY_BINARY_LENGTH, "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
+  static_assert(mapping_value::BUFFER_SIZE >= LOKINET_ADDRESS_BINARY_LENGTH,    "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
+  static_assert(mapping_value::BUFFER_SIZE >= sizeof(addr_info.address),        "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
   if (type == static_cast<uint16_t>(mapping_type::wallet))
   {
     if (value.empty() || !get_account_address_from_str(addr_info, nettype, value))
@@ -514,7 +523,7 @@ bool validate_lns_value(cryptonote::network_type nettype, uint16_t type, std::st
       if (hex::char_is_hex(a) && hex::char_is_hex(b))
       {
         if (blob) // NOTE: Given blob, write the binary output
-          blob->buffer.data()[blob->len++] = hex::from_hex_pair(a, b);
+          blob->buffer[blob->len++] = hex::from_hex_pair(a, b);
       }
       else
       {
@@ -543,13 +552,13 @@ bool validate_lns_value(cryptonote::network_type nettype, uint16_t type, std::st
   return true;
 }
 
-bool validate_lns_value_binary(uint16_t type, std::string const &value, std::string *reason)
+bool validate_encrypted_mapping_value(uint16_t type, std::string const &value, std::string *reason)
 {
   std::stringstream err_stream;
-  int max_value_len            = 0;
-  if (type == static_cast<uint16_t>(mapping_type::lokinet))      max_value_len = LOKINET_ADDRESS_BINARY_LENGTH;
-  else if (type == static_cast<uint16_t>(mapping_type::session)) max_value_len = SESSION_PUBLIC_KEY_BINARY_LENGTH;
-  else if (type == static_cast<uint16_t>(mapping_type::wallet))  max_value_len = sizeof(cryptonote::account_public_address);
+  int max_value_len = crypto_secretbox_MACBYTES;
+  if (type == static_cast<uint16_t>(mapping_type::lokinet))      max_value_len += LOKINET_ADDRESS_BINARY_LENGTH;
+  else if (type == static_cast<uint16_t>(mapping_type::session)) max_value_len += SESSION_PUBLIC_KEY_BINARY_LENGTH;
+  else if (type == static_cast<uint16_t>(mapping_type::wallet))  max_value_len += sizeof(cryptonote::account_public_address);
   else
   {
     if (reason)
@@ -702,9 +711,8 @@ bool name_system_db::validate_lns_tx(uint8_t hf_version, uint64_t blockchain_hei
     }
     return false;
   }
-  uint64_t burn = cryptonote::get_burned_amount_from_tx_extra(tx.extra);
 
-  if (!validate_lns_value_binary(entry->type, entry->value, reason))
+  if (!validate_encrypted_mapping_value(entry->type, entry->encrypted_value, reason))
       return false;
 
   if (!validate_against_previous_mapping(*this, blockchain_height, tx, *entry, reason))
@@ -721,6 +729,7 @@ bool name_system_db::validate_lns_tx(uint8_t hf_version, uint64_t blockchain_hei
     return false;
   }
 
+  uint64_t burn                = cryptonote::get_burned_amount_from_tx_extra(tx.extra);
   auto lns_type                = static_cast<mapping_type>(entry->type);
   uint64_t const burn_required = burn_requirement_in_atomic_loki(hf_version, mapping_type_to_burn_type(lns_type));
   if (burn != burn_required)
@@ -784,6 +793,56 @@ crypto::hash name_to_hash(std::string const &name)
   return result;
 }
 
+struct alignas(size_t) secretbox_secret_key_ { unsigned char data[crypto_secretbox_KEYBYTES]; };
+using secretbox_secret_key = epee::mlocked<tools::scrubbed<secretbox_secret_key_>>;
+
+static bool name_to_encryption_key(std::string const &name, secretbox_secret_key &out)
+{
+  static_assert(sizeof(out) >= crypto_secretbox_KEYBYTES, "Encrypting key needs to have sufficient space for running encryption functions via libsodium");
+  static unsigned char constexpr SALT[crypto_pwhash_SALTBYTES] = {};
+  bool result = (crypto_pwhash(out.data, sizeof(out), name.data(), name.size(), SALT, crypto_pwhash_OPSLIMIT_MODERATE, crypto_pwhash_MEMLIMIT_MODERATE, crypto_pwhash_ALG_ARGON2ID13) == 0);
+  return result;
+}
+
+static unsigned char const ENCRYPTION_NONCE[crypto_secretbox_NONCEBYTES] = {}; // NOTE: Not meant to be secure
+bool encrypt_mapping_value(std::string const &name, mapping_value const &value, mapping_value &encrypted_value)
+{
+  bool result                 = false;
+  size_t const encryption_len = value.len + crypto_secretbox_MACBYTES;
+  if (encryption_len > encrypted_value.buffer.size())
+  {
+    MERROR("Encrypted value pre-allocated buffer too small=" << encrypted_value.buffer.size() << ", required=" << encryption_len);
+    return result;
+  }
+
+  encrypted_value     = {};
+  encrypted_value.len = encryption_len;
+
+  secretbox_secret_key skey;
+  if (name_to_encryption_key(name, skey))
+    result = (crypto_secretbox_easy(encrypted_value.buffer.data(), value.buffer.data(), value.len, ENCRYPTION_NONCE, reinterpret_cast<unsigned char *>(&skey)) == 0);
+  return result;
+}
+
+bool decrypt_mapping_value(std::string const &name, mapping_value const &encrypted_value, mapping_value &value)
+{
+  bool result = false;
+  if (encrypted_value.len <= crypto_secretbox_MACBYTES)
+  {
+    MERROR("Encrypted value is too short=" << encrypted_value.len << ", at least required=" << crypto_secretbox_MACBYTES + 1);
+    return result;
+  }
+
+  value     = {};
+  value.len = encrypted_value.len - crypto_secretbox_MACBYTES;
+
+  secretbox_secret_key skey;
+  if (name_to_encryption_key(name, skey))
+    result = crypto_secretbox_open_easy(value.buffer.data(), encrypted_value.buffer.data(), encrypted_value.len, ENCRYPTION_NONCE, reinterpret_cast<unsigned char *>(&skey)) == 0;
+  return result;
+}
+
+
 static bool build_default_tables(sqlite3 *db)
 {
   constexpr char BUILD_TABLE_SQL[] = R"(
@@ -803,7 +862,7 @@ CREATE TABLE IF NOT EXISTS "mappings" (
     "id" INTEGER PRIMARY KEY NOT NULL,
     "type" INTEGER NOT NULL,
     "name_hash" BLOB NOT NULL,
-    "value" BLOB NOT NULL,
+    "encrypted_value" BLOB NOT NULL,
     "txid" BLOB NOT NULL,
     "prev_txid" BLOB NOT NULL,
     "register_height" INTEGER NOT NULL,
@@ -840,7 +899,7 @@ bool name_system_db::init(cryptonote::network_type nettype, sqlite3 *db, uint64_
   char constexpr GET_SETTINGS_SQL[]                     = R"(SELECT * FROM "settings" WHERE "id" = 1)";
   char constexpr PRUNE_MAPPINGS_SQL[]                   = R"(DELETE FROM "mappings" WHERE "register_height" >= ?)";
   char constexpr PRUNE_OWNERS_SQL[]                     = R"(DELETE FROM "owner" WHERE "id" NOT IN (SELECT "owner_id" FROM "mappings"))";
-  char constexpr SAVE_MAPPING_SQL[]                     = R"(INSERT OR REPLACE INTO "mappings" ("type", "name_hash", "value", "txid", "prev_txid", "register_height", "owner_id") VALUES (?,?,?,?,?,?,?))";
+  char constexpr SAVE_MAPPING_SQL[]                     = R"(INSERT OR REPLACE INTO "mappings" ("type", "name_hash", "encrypted_value", "txid", "prev_txid", "register_height", "owner_id") VALUES (?,?,?,?,?,?,?))";
   char constexpr SAVE_OWNER_SQL[]                       = R"(INSERT INTO "owner" ("public_key") VALUES (?);)";
   char constexpr SAVE_SETTINGS_SQL[]                    = R"(INSERT OR REPLACE INTO "settings" ("id", "top_height", "top_hash", "version") VALUES (1,?,?,?))";
 
@@ -1104,7 +1163,7 @@ bool name_system_db::save_mapping(crypto::hash const &tx_hash, cryptonote::tx_ex
   sqlite3_stmt *statement = save_mapping_sql;
   sqlite3_bind_int  (statement, static_cast<int>(mapping_record_row::type), static_cast<uint16_t>(src.type));
   sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::name_hash), src.name_hash.data, sizeof(src.name_hash), nullptr /*destructor*/);
-  sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::value), src.value.data(), src.value.size(), nullptr /*destructor*/);
+  sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::encrypted_value), src.encrypted_value.data(), src.encrypted_value.size(), nullptr /*destructor*/);
   sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::txid), tx_hash.data, sizeof(tx_hash), nullptr /*destructor*/);
   sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::prev_txid), src.prev_txid.data, sizeof(src.prev_txid), nullptr /*destructor*/);
   sqlite3_bind_int64(statement, static_cast<int>(mapping_record_row::register_height), static_cast<int64_t>(height));

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -422,11 +422,8 @@ bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std
   if (blob) *blob = {};
   std::stringstream err_stream;
 
+  // Check length of the value
   cryptonote::address_parse_info addr_info = {};
-
-  static_assert(mapping_value::BUFFER_SIZE >= SESSION_PUBLIC_KEY_BINARY_LENGTH, "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
-  static_assert(mapping_value::BUFFER_SIZE >= LOKINET_ADDRESS_BINARY_LENGTH,    "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
-  static_assert(mapping_value::BUFFER_SIZE >= sizeof(addr_info.address),        "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
   if (type == static_cast<uint16_t>(mapping_type::wallet))
   {
     if (value.empty() || !get_account_address_from_str(addr_info, nettype, value))
@@ -456,7 +453,7 @@ bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std
     {
       if (reason)
       {
-        err_stream << "Unhandled type passed into " << __func__;
+        err_stream << "Unhandled type passed into: " << __func__;
         *reason = err_stream.str();
       }
       return false;
@@ -466,6 +463,7 @@ bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std
       return false;
   }
 
+  // Validate blob contents and generate the binary form if possible
   if (type == static_cast<uint16_t>(mapping_type::wallet))
   {
     if (blob)
@@ -505,6 +503,7 @@ bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std
   }
   else
   {
+    assert(type == static_cast<uint16_t>(mapping_type::session));
     // NOTE: Check value is hex
     if ((value.size() % 2) != 0)
     {
@@ -536,19 +535,17 @@ bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std
       }
     }
 
-    if (type == static_cast<uint16_t>(mapping_type::session))
+    if (!(value[0] == '0' && value[1] == '5')) // NOTE: Session public keys are 33 bytes, with the first byte being 0x05 and the remaining 32 being the public key.
     {
-      if (!(value[0] == '0' && value[1] == '5')) // NOTE: Session public keys are 33 bytes, with the first byte being 0x05 and the remaining 32 being the public key.
+      if (reason)
       {
-        if (reason)
-        {
-          err_stream << "LNS type=session, specifies mapping from name_hash->ed25519 key where the key is not prefixed with 53 (0x05), prefix=" << std::to_string(value[0]) << " (" << value[0] << "), given ed25519=" << value;
-          *reason = err_stream.str();
-        }
-        return false;
+        err_stream << "LNS type=session, specifies mapping from name_hash->ed25519 key where the key is not prefixed with 53 (0x05), prefix=" << std::to_string(value[0]) << " (" << value[0] << "), given ed25519=" << value;
+        *reason = err_stream.str();
       }
+      return false;
     }
   }
+
   return true;
 }
 
@@ -804,9 +801,13 @@ static bool name_to_encryption_key(std::string const &name, secretbox_secret_key
   return result;
 }
 
-static unsigned char const ENCRYPTION_NONCE[crypto_secretbox_NONCEBYTES] = {}; // NOTE: Not meant to be secure
+static unsigned char const ENCRYPTION_NONCE[crypto_secretbox_NONCEBYTES] = {}; // NOTE: Not meant to be extremely secure, just use an empty nonce
 bool encrypt_mapping_value(std::string const &name, mapping_value const &value, mapping_value &encrypted_value)
 {
+  static_assert(mapping_value::BUFFER_SIZE >= SESSION_PUBLIC_KEY_BINARY_LENGTH + crypto_secretbox_MACBYTES, "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
+  static_assert(mapping_value::BUFFER_SIZE >= LOKINET_ADDRESS_BINARY_LENGTH    + crypto_secretbox_MACBYTES, "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
+  static_assert(mapping_value::BUFFER_SIZE >= WALLET_ACCOUNT_BINARY_LENGTH     + crypto_secretbox_MACBYTES, "Value blob assumes the largest size required, all other values should be able to fit into this buffer");
+
   bool result                 = false;
   size_t const encryption_len = value.len + crypto_secretbox_MACBYTES;
   if (encryption_len > encrypted_value.buffer.size())
@@ -1112,13 +1113,13 @@ static bool find_closest_valid_lns_tx_extra_in_blockchain(cryptonote::Blockchain
   return result;
 }
 
-void name_system_db::block_detach(cryptonote::Blockchain const &blockchain, uint64_t height)
+void name_system_db::block_detach(cryptonote::Blockchain const &blockchain, uint64_t new_blockchain_height)
 {
   std::vector<mapping_record> new_mappings = {};
   {
     sqlite3_stmt *statement = get_mappings_on_height_and_newer_sql;
     sqlite3_clear_bindings(statement);
-    sqlite3_bind_int(statement, 1 /*sql param index*/, height);
+    sqlite3_bind_int(statement, 1 /*sql param index*/, new_blockchain_height);
     sql_run_statement(nettype, lns_sql_type::get_mappings_on_height_and_newer, statement, &new_mappings);
   }
 
@@ -1135,11 +1136,11 @@ void name_system_db::block_detach(cryptonote::Blockchain const &blockchain, uint
     cryptonote::tx_extra_loki_name_system entry = {};
     uint64_t entry_height                       = 0;
     crypto::hash tx_hash                        = {};
-    if (!find_closest_valid_lns_tx_extra_in_blockchain(blockchain, mapping, height, entry, tx_hash, entry_height)) continue;
+    if (!find_closest_valid_lns_tx_extra_in_blockchain(blockchain, mapping, new_blockchain_height, entry, tx_hash, entry_height)) continue;
     entries.push_back({entry_height, tx_hash, entry});
   }
 
-  prune_db(height);
+  prune_db(new_blockchain_height);
   for (auto const &lns : entries)
   {
     if (!add_lns_entry(*this, lns.height, lns.entry, lns.tx_hash))

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -58,7 +58,7 @@ enum struct mapping_record_row
 {
   id,
   type,
-  name,
+  name_hash,
   value,
   txid,
   prev_txid,
@@ -134,14 +134,12 @@ static bool sql_run_statement(cryptonote::network_type nettype, lns_sql_type typ
             tmp_entry.register_height = static_cast<uint16_t>(sqlite3_column_int(statement, static_cast<int>(mapping_record_row::register_height)));
             tmp_entry.owner_id = sqlite3_column_int(statement, static_cast<int>(mapping_record_row::owner_id));
 
-            int name_len  = sqlite3_column_bytes(statement, static_cast<int>(mapping_record_row::name));
-            auto *name    = reinterpret_cast<char const *>(sqlite3_column_text(statement, static_cast<int>(mapping_record_row::name)));
-
             size_t value_len = static_cast<size_t>(sqlite3_column_bytes(statement, static_cast<int>(mapping_record_row::value)));
             auto *value      = reinterpret_cast<char const *>(sqlite3_column_text(statement, static_cast<int>(mapping_record_row::value)));
-
-            tmp_entry.name  = std::string(name, name_len);
             tmp_entry.value = std::string(value, value_len);
+
+            if (!sql_copy_blob(statement, static_cast<int>(mapping_record_row::name_hash), tmp_entry.name_hash.data, sizeof(tmp_entry.name_hash)))
+              return false;
 
             if (!sql_copy_blob(statement, static_cast<int>(mapping_record_row::txid), tmp_entry.txid.data, sizeof(tmp_entry.txid)))
               return false;
@@ -410,7 +408,7 @@ static bool check_lengths(uint16_t type, std::string const &value, size_t max, b
     if (reason)
     {
       std::stringstream err_stream;
-      err_stream << "LNS type=" << type << ", specifies mapping from name -> value where the value's length=" << value.size();
+      err_stream << "LNS type=" << type << ", specifies mapping from name_hash->value where the value's length=" << value.size();
       if (require_exact_len) err_stream << ", does not equal the required length=";
       else                   err_stream <<" is 0 or exceeds the maximum length=";
       err_stream << max << ", given value=" << value;
@@ -526,7 +524,7 @@ bool validate_lns_value(cryptonote::network_type nettype, uint16_t type, std::st
       {
         if (reason)
         {
-          err_stream << "LNS type=" << type <<", specifies name -> value mapping where the value is not a hex string given value=" << value;
+          err_stream << "LNS type=" << type <<", specifies name_hash->value mapping where the value is not a hex string given value=" << value;
           *reason = err_stream.str();
         }
         return false;
@@ -539,7 +537,7 @@ bool validate_lns_value(cryptonote::network_type nettype, uint16_t type, std::st
       {
         if (reason)
         {
-          err_stream << "LNS type=session, specifies mapping from name -> ed25519 key where the key is not prefixed with 53 (0x05), prefix=" << std::to_string(value[0]) << " (" << value[0] << "), given ed25519=" << value;
+          err_stream << "LNS type=session, specifies mapping from name_hash->ed25519 key where the key is not prefixed with 53 (0x05), prefix=" << std::to_string(value[0]) << " (" << value[0] << "), given ed25519=" << value;
           *reason = err_stream.str();
         }
         return false;
@@ -571,7 +569,7 @@ bool validate_lns_value_binary(uint16_t type, std::string const &value, std::str
       if (reason)
       {
         std::stringstream err_stream;
-        err_stream << "LNS type=" << type << ", specifies mapping from name -> wallet address where the wallet address's blob, does not generate valid public spend/view keys";
+        err_stream << "LNS type=" << type << ", specifies mapping from name_hash->wallet address where the wallet address's blob, does not generate valid public spend/view keys";
         *reason = err_stream.str();
       }
       return false;
@@ -582,7 +580,7 @@ bool validate_lns_value_binary(uint16_t type, std::string const &value, std::str
 
 static std::stringstream &error_stream_append_tx_msg(std::stringstream &err_stream, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system const &data)
 {
-  err_stream << "TX type=" << tx.type << ", tx=" << get_transaction_hash(tx) << ", owner=" << data.owner << ", type=" << (int)data.type << ", name=" << data.name << ", ";
+  err_stream << "TX type=" << tx.type << ", tx=" << get_transaction_hash(tx) << ", owner=" << data.owner << ", type=" << (int)data.type << ", name_hash=" << data.name_hash << ", ";
   return err_stream;
 }
 
@@ -590,14 +588,14 @@ static bool validate_against_previous_mapping(lns::name_system_db const &lns_db,
 {
   std::stringstream err_stream;
   crypto::hash expected_prev_txid = crypto::null_hash;
-  if (lns::mapping_record mapping = lns_db.get_mapping(data.type, data.name))
+  if (lns::mapping_record mapping = lns_db.get_mapping(data.type, data.name_hash))
   {
     if (data.type != static_cast<uint16_t>(lns::mapping_type::lokinet))
     {
       if (reason)
       {
         lns::owner_record owner = lns_db.get_owner_by_id(mapping.owner_id);
-        error_stream_append_tx_msg(err_stream, tx, data) << "non-lokinet entries can NOT be renewed, mapping already exists with name=" << mapping.name << ", owner=" << owner.key << ", type=" << mapping.type;
+        error_stream_append_tx_msg(err_stream, tx, data) << "non-lokinet entries can NOT be renewed, mapping already exists with name_hash=" << mapping.name_hash << ", owner=" << owner.key << ", type=" << mapping.type;
         *reason = err_stream.str();
       }
       return false;
@@ -702,14 +700,23 @@ bool name_system_db::validate_lns_tx(uint8_t hf_version, uint64_t blockchain_hei
     return false;
   }
   uint64_t burn = cryptonote::get_burned_amount_from_tx_extra(tx.extra);
-  if (!validate_lns_name(entry->type, entry->name, reason))
-    return false;
 
   if (!validate_lns_value_binary(entry->type, entry->value, reason))
-    return false;
+      return false;
 
   if (!validate_against_previous_mapping(*this, blockchain_height, tx, *entry, reason))
     return false;
+
+  static const crypto::hash null_name_hash = name_to_hash(""); // Sanity check the empty name hash
+  if (entry->name_hash == null_name_hash || entry->name_hash == crypto::null_hash)
+  {
+    if (reason)
+    {
+      err_stream << "LNS TX=" << cryptonote::get_transaction_hash(tx) << ", specified the null name hash";
+      *reason = err_stream.str();
+    }
+    return false;
+  }
 
   auto lns_type                = static_cast<mapping_type>(entry->type);
   uint64_t const burn_required = burn_requirement_in_atomic_loki(hf_version, mapping_type_to_burn_type(lns_type));
@@ -761,6 +768,19 @@ bool validate_mapping_type(std::string const &type, uint16_t *mapping_type, std:
   return true;
 }
 
+crypto::hash name_to_hash(std::string const &name)
+{
+  crypto::hash result = {};
+  static_assert(sizeof(result) >= crypto_generichash_BYTES, "Sodium can generate arbitrary length hashes, but recommend the minimum size for a secure hash must be >= crypto_generichash_BYTES");
+  crypto_generichash_blake2b(reinterpret_cast<unsigned char *>(result.data),
+                             sizeof(result),
+                             reinterpret_cast<const unsigned char *>(name.data()),
+                             static_cast<unsigned long long>(name.size()),
+                             nullptr /*key*/,
+                             0 /*keylen*/);
+  return result;
+}
+
 static bool build_default_tables(sqlite3 *db)
 {
   constexpr char BUILD_TABLE_SQL[] = R"(
@@ -779,14 +799,14 @@ CREATE TABLE IF NOT EXISTS "settings" (
 CREATE TABLE IF NOT EXISTS "mappings" (
     "id" INTEGER PRIMARY KEY NOT NULL,
     "type" INTEGER NOT NULL,
-    "name" VARCHAR NOT NULL,
+    "name_hash" BLOB NOT NULL,
     "value" BLOB NOT NULL,
     "txid" BLOB NOT NULL,
     "prev_txid" BLOB NOT NULL,
     "register_height" INTEGER NOT NULL,
     "owner_id" INTEGER NOT NULL REFERENCES "owner" ("id")
 );
-CREATE UNIQUE INDEX IF NOT EXISTS "name_type_id" ON mappings("name", "type");
+CREATE UNIQUE INDEX IF NOT EXISTS "name_hash_type_id" ON mappings("name_hash", "type");
 )";
 
   char *table_err_msg = nullptr;
@@ -811,13 +831,13 @@ bool name_system_db::init(cryptonote::network_type nettype, sqlite3 *db, uint64_
 
   char constexpr GET_MAPPINGS_BY_OWNER_SQL[]            = R"(SELECT * FROM "mappings" JOIN "owner" ON "mappings"."owner_id" = "owner"."id" WHERE "public_key" = ?)";
   char constexpr GET_MAPPINGS_ON_HEIGHT_AND_NEWER_SQL[] = R"(SELECT * FROM "mappings" JOIN "owner" on "mappings"."owner_id" = "owner"."id" WHERE "register_height" >= ?)";
-  char constexpr GET_MAPPING_SQL[]                      = R"(SELECT * FROM "mappings" JOIN "owner" on "mappings"."owner_id" = "owner"."id" WHERE "type" = ? AND "name" = ?)";
+  char constexpr GET_MAPPING_SQL[]                      = R"(SELECT * FROM "mappings" JOIN "owner" on "mappings"."owner_id" = "owner"."id" WHERE "type" = ? AND "name_hash" = ?)";
   char constexpr GET_OWNER_BY_ID_SQL[]                  = R"(SELECT * FROM "owner" WHERE "id" = ?)";
   char constexpr GET_OWNER_BY_KEY_SQL[]                 = R"(SELECT * FROM "owner" WHERE "public_key" = ?)";
   char constexpr GET_SETTINGS_SQL[]                     = R"(SELECT * FROM "settings" WHERE "id" = 1)";
   char constexpr PRUNE_MAPPINGS_SQL[]                   = R"(DELETE FROM "mappings" WHERE "register_height" >= ?)";
   char constexpr PRUNE_OWNERS_SQL[]                     = R"(DELETE FROM "owner" WHERE "id" NOT IN (SELECT "owner_id" FROM "mappings"))";
-  char constexpr SAVE_MAPPING_SQL[]                     = R"(INSERT OR REPLACE INTO "mappings" ("type", "name", "value", "txid", "prev_txid", "register_height", "owner_id") VALUES (?,?,?,?,?,?,?))";
+  char constexpr SAVE_MAPPING_SQL[]                     = R"(INSERT OR REPLACE INTO "mappings" ("type", "name_hash", "value", "txid", "prev_txid", "register_height", "owner_id") VALUES (?,?,?,?,?,?,?))";
   char constexpr SAVE_OWNER_SQL[]                       = R"(INSERT INTO "owner" ("public_key") VALUES (?);)";
   char constexpr SAVE_SETTINGS_SQL[]                    = R"(INSERT OR REPLACE INTO "settings" ("id", "top_height", "top_hash", "version") VALUES (1,?,?,?))";
 
@@ -920,7 +940,7 @@ static bool add_lns_entry(lns::name_system_db &lns_db, uint64_t height, cryptono
   {
     if (!lns_db.save_owner(entry.owner, &owner_id))
     {
-      LOG_PRINT_L1("Failed to save LNS owner to DB tx: " << tx_hash << ", type: " << (uint16_t)entry.type << ", name: " << entry.name << ", owner: " << entry.owner);
+      LOG_PRINT_L1("Failed to save LNS user to DB tx: " << tx_hash << ", type: " << (uint16_t)entry.type << ", name_hash: " << entry.name_hash << ", user: " << entry.owner);
       return false;
     }
   }
@@ -928,7 +948,7 @@ static bool add_lns_entry(lns::name_system_db &lns_db, uint64_t height, cryptono
 
   if (!lns_db.save_mapping(tx_hash, entry, height, owner_id))
   {
-    LOG_PRINT_L1("Failed to save LNS entry to DB tx: " << tx_hash << ", type: " << (uint16_t)entry.type << ", name: " << entry.name << ", owner: " << entry.owner);
+    LOG_PRINT_L1("Failed to save LNS entry to DB tx: " << tx_hash << ", type: " << (uint16_t)entry.type << ", name_hash: " << entry.name_hash << ", user: " << entry.owner);
     return false;
   }
 
@@ -1080,7 +1100,7 @@ bool name_system_db::save_mapping(crypto::hash const &tx_hash, cryptonote::tx_ex
 {
   sqlite3_stmt *statement = save_mapping_sql;
   sqlite3_bind_int  (statement, static_cast<int>(mapping_record_row::type), static_cast<uint16_t>(src.type));
-  sqlite3_bind_text (statement, static_cast<int>(mapping_record_row::name), src.name.data(), src.name.size(), nullptr /*destructor*/);
+  sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::name_hash), src.name_hash.data, sizeof(src.name_hash), nullptr /*destructor*/);
   sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::value), src.value.data(), src.value.size(), nullptr /*destructor*/);
   sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::txid), tx_hash.data, sizeof(tx_hash), nullptr /*destructor*/);
   sqlite3_bind_blob (statement, static_cast<int>(mapping_record_row::prev_txid), src.prev_txid.data, sizeof(src.prev_txid), nullptr /*destructor*/);
@@ -1138,24 +1158,24 @@ owner_record name_system_db::get_owner_by_id(int64_t owner_id) const
   return result;
 }
 
-mapping_record name_system_db::get_mapping(uint16_t type, std::string const &name) const
+mapping_record name_system_db::get_mapping(uint16_t type, crypto::hash const &name_hash) const
 {
   sqlite3_stmt *statement = get_mapping_sql;
   sqlite3_clear_bindings(statement);
   sqlite3_bind_int(statement, 1 /*sql param index*/, type);
-  sqlite3_bind_text(statement, 2 /*sql param index*/, name.data(), name.size(), nullptr /*destructor*/);
+  sqlite3_bind_blob(statement, 2 /*sql param index*/, name_hash.data, sizeof(name_hash), nullptr /*destructor*/);
 
   mapping_record result = {};
   result.loaded         = sql_run_statement(nettype, lns_sql_type::get_mapping, statement, &result);
   return result;
 }
 
-std::vector<mapping_record> name_system_db::get_mappings(std::vector<uint16_t> const &types, std::string const &name) const
+std::vector<mapping_record> name_system_db::get_mappings(std::vector<uint16_t> const &types, crypto::hash const &name_hash) const
 {
   std::string sql_statement;
   // Generate string statement
   {
-    char constexpr SQL_PREFIX[] = R"(SELECT * FROM "mappings" JOIN "owner" ON "mappings"."owner_id" = "owner"."id" WHERE "name" = ? AND "type" in ()";
+    char constexpr SQL_PREFIX[] = R"(SELECT * FROM "mappings" JOIN "owner" ON "mappings"."owner_id" = "owner"."id" WHERE "name_hash" = ? AND "type" in ()";
     char constexpr SQL_SUFFIX[] = R"())";
 
     std::stringstream stream;
@@ -1177,7 +1197,7 @@ std::vector<mapping_record> name_system_db::get_mappings(std::vector<uint16_t> c
 
   // Bind parameters statements
   int sql_param_index = 1;
-  sqlite3_bind_text(statement, sql_param_index++, name.data(), name.size(), nullptr /*destructor*/);
+  sqlite3_bind_blob(statement, sql_param_index++, name_hash.data, sizeof(name_hash), nullptr /*destructor*/);
   for (auto type : types)
     sqlite3_bind_int(statement, sql_param_index++, type);
   assert((sql_param_index - 1) == static_cast<int>(1 /*name*/ + types.size()));

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -401,7 +401,7 @@ bool validate_lns_name(uint16_t type, std::string const &name, std::string *reas
   return true;
 }
 
-static bool check_lengths(uint16_t type, std::string const &value, size_t max, std::string *reason)
+static bool check_lengths(uint16_t type, std::string const &value, size_t max, bool binary_val, std::string *reason)
 {
   bool result = (value.size() == max);
   if (!result)
@@ -409,7 +409,9 @@ static bool check_lengths(uint16_t type, std::string const &value, size_t max, s
     if (reason)
     {
       std::stringstream err_stream;
-      err_stream << "LNS type=" << type << ", specifies mapping from name_hash->encrypted_value where the value's length=" << value.size() << ", does not equal the required length=" << max << ", given value=" << value;
+      err_stream << "LNS type=" << type << ", specifies mapping from name_hash->encrypted_value where the value's length=" << value.size() << ", does not equal the required length=" << max << ", given value=";
+      if (binary_val) err_stream << epee::to_hex::string(epee::span<const uint8_t>(reinterpret_cast<uint8_t const *>(value.data()), value.size()));
+      else            err_stream << value;
       *reason = err_stream.str();
     }
   }
@@ -459,7 +461,7 @@ bool validate_mapping_value(cryptonote::network_type nettype, uint16_t type, std
       return false;
     }
 
-    if (!check_lengths(type, value, max_value_len, reason))
+    if (!check_lengths(type, value, max_value_len, false /*binary_val*/, reason))
       return false;
   }
 
@@ -555,7 +557,7 @@ bool validate_encrypted_mapping_value(uint16_t type, std::string const &value, s
   int max_value_len = crypto_secretbox_MACBYTES;
   if (type == static_cast<uint16_t>(mapping_type::lokinet))      max_value_len += LOKINET_ADDRESS_BINARY_LENGTH;
   else if (type == static_cast<uint16_t>(mapping_type::session)) max_value_len += SESSION_PUBLIC_KEY_BINARY_LENGTH;
-  else if (type == static_cast<uint16_t>(mapping_type::wallet))  max_value_len += sizeof(cryptonote::account_public_address);
+  else if (type == static_cast<uint16_t>(mapping_type::wallet))  max_value_len += WALLET_ACCOUNT_BINARY_LENGTH;
   else
   {
     if (reason)
@@ -566,24 +568,8 @@ bool validate_encrypted_mapping_value(uint16_t type, std::string const &value, s
     return false;
   }
 
-  if (!check_lengths(type, value, max_value_len, reason))
+  if (!check_lengths(type, value, max_value_len, true /*binary_val*/, reason))
     return false;
-
-  if (type == static_cast<uint16_t>(lns::mapping_type::wallet))
-  {
-    // TODO(doyle): Better address validation? Is it a valid address, is it a valid nettype address?
-    cryptonote::account_public_address address;
-    memcpy(&address, value.data(), sizeof(address));
-    if (!(crypto::check_key(address.m_spend_public_key) && crypto::check_key(address.m_view_public_key)))
-    {
-      if (reason)
-      {
-        err_stream << "LNS type=" << type << ", specifies mapping from name_hash->wallet address where the wallet address's blob, does not generate valid public spend/view keys";
-        *reason = err_stream.str();
-      }
-      return false;
-    }
-  }
   return true;
 }
 

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -26,12 +26,11 @@ constexpr size_t LOKINET_DOMAIN_NAME_MAX          = 253;
 constexpr size_t LOKINET_ADDRESS_BINARY_LENGTH    = sizeof(crypto::ed25519_public_key);
 constexpr size_t SESSION_DISPLAY_NAME_MAX         = 64;
 constexpr size_t SESSION_PUBLIC_KEY_BINARY_LENGTH = 1 + sizeof(crypto::ed25519_public_key); // Session keys at prefixed with 0x05 + ed25519 key
-constexpr size_t GENERIC_NAME_MAX                 = 255;
-constexpr size_t GENERIC_VALUE_MAX                = 255;
 
 struct lns_value
 {
-  std::array<uint8_t, lns::GENERIC_VALUE_MAX> buffer;
+  static size_t constexpr BUFFER_SIZE = 255;
+  std::array<uint8_t, BUFFER_SIZE> buffer;
   size_t len;
 };
 

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -64,6 +64,7 @@ bool         validate_lns_name(uint16_t type, std::string const &name, std::stri
 bool         validate_lns_value(cryptonote::network_type nettype, uint16_t type, std::string const &value, lns_value *blob = nullptr, std::string *reason = nullptr);
 bool         validate_lns_value_binary(uint16_t type, std::string const &value, std::string *reason = nullptr);
 bool         validate_mapping_type(std::string const &type, uint16_t *mapping_type, std::string *reason);
+crypto::hash name_to_hash(std::string const &name);
 
 struct owner_record
 {
@@ -96,7 +97,7 @@ struct mapping_record
 
   bool                       loaded;
   uint16_t                   type; // alias to lns::mapping_type
-  std::string                name;
+  crypto::hash               name_hash;
   std::string                value;
   uint64_t                   register_height;
   int64_t                    owner_id;
@@ -121,8 +122,8 @@ struct name_system_db
 
   owner_record                get_owner_by_key      (crypto::ed25519_public_key const &key) const;
   owner_record                get_owner_by_id       (int64_t owner_id) const;
-  mapping_record              get_mapping           (uint16_t type, std::string const &name) const;
-  std::vector<mapping_record> get_mappings          (std::vector<uint16_t> const &types, std::string const &name) const;
+  mapping_record              get_mapping           (uint16_t type, crypto::hash const &name_hash) const;
+  std::vector<mapping_record> get_mappings          (std::vector<uint16_t> const &types, crypto::hash const &name) const;
   std::vector<mapping_record> get_mappings_by_owner (crypto::ed25519_public_key const &key) const;
   std::vector<mapping_record> get_mappings_by_owners(std::vector<crypto::ed25519_public_key> const &keys) const;
   settings_record             get_settings          () const;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -238,7 +238,7 @@ namespace cryptonote
           return true;
         }
 
-        if (data.type == pool_data.type && data.name == pool_data.name)
+        if (data.type == pool_data.type && data.name_hash == pool_data.name_hash)
         {
           LOG_PRINT_L1("New TX: " << get_transaction_hash(tx) << ", has TX: " << get_transaction_hash(pool_tx) << " from the pool that is requesting the same LNS entry already.");
           return true;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3369,7 +3369,8 @@ namespace cryptonote
       if (exceeds_quantity_limit(ctx, error_resp, m_restricted, request.types.size(), COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::MAX_TYPE_REQUEST_ENTRIES, "types"))
         return false;
 
-      std::vector<lns::mapping_record> records = db.get_mappings(request.types, request.name);
+      crypto::hash name_hash = lns::name_to_hash(request.name);
+      std::vector<lns::mapping_record> records = db.get_mappings(request.types, name_hash);
       res.entries.reserve(records.size());
       for (auto const &record : records)
       {
@@ -3430,7 +3431,7 @@ namespace cryptonote
 
       entry.request_index   = it->second;
       entry.type            = mapping.type;
-      entry.name            = mapping.name;
+      entry.name_hash       = epee::string_tools::pod_to_hex(mapping.name_hash);
       entry.value           = extract_lns_mapping_value(mapping);
       entry.register_height = mapping.register_height;
       entry.txid            = epee::string_tools::pod_to_hex(mapping.txid);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3341,22 +3341,6 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  static std::string extract_lns_mapping_value(lns::mapping_record const &record)
-  {
-    std::string result;
-    if (static_cast<lns::mapping_type>(record.type) == lns::mapping_type::lokinet)
-    {
-      char buf[64] = {};
-      base32z::encode(record.value, buf);
-      result = std::string(buf) + ".loki";
-    }
-    else
-    {
-      result = epee::to_hex::string(epee::span<const uint8_t>(reinterpret_cast<const uint8_t *>(record.value.data()), record.value.size()));
-    }
-    return result;
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_lns_names_to_owners(const COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::request &req, COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::response &res, epee::json_rpc::error &error_resp, const connection_context *ctx)
   {
     if (exceeds_quantity_limit(ctx, error_resp, m_restricted, req.entries.size(), COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::MAX_REQUEST_ENTRIES))
@@ -3379,7 +3363,7 @@ namespace cryptonote
         entry.entry_index         = request_index;
         entry.type                = record.type;
         entry.owner               = epee::string_tools::pod_to_hex(record.owner);
-        entry.value               = extract_lns_mapping_value(record);
+        entry.encrypted_value     = epee::to_hex::string(epee::span<const uint8_t>(record.encrypted_value.buffer.data(), record.encrypted_value.len));
         entry.register_height     = record.register_height;
         entry.txid                = epee::string_tools::pod_to_hex(record.txid);
         entry.prev_txid           = epee::string_tools::pod_to_hex(record.prev_txid);
@@ -3415,27 +3399,27 @@ namespace cryptonote
     }
 
     lns::name_system_db const &db = m_core.get_blockchain_storage().name_system_db();
-    std::vector<lns::mapping_record> db_mappings = db.get_mappings_by_owners(keys);
-    for (lns::mapping_record const &mapping : db_mappings)
+    std::vector<lns::mapping_record> records = db.get_mappings_by_owners(keys);
+    for (auto const &record : records)
     {
       res.entries.emplace_back();
       COMMAND_RPC_GET_LNS_OWNERS_TO_NAMES::response_entry &entry = res.entries.back();
 
-      auto it = key_to_request_index.find(mapping.owner);
+      auto it = key_to_request_index.find(record.owner);
       if (it == key_to_request_index.end())
       {
         error_resp.code    = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
-        error_resp.message = "Public key=" + epee::string_tools::pod_to_hex(mapping.owner) + ", could not be mapped back a index in the request 'entries' array";
+        error_resp.message = "Public key=" + epee::string_tools::pod_to_hex(record.owner) + ", could not be mapped back a index in the request 'entries' array";
         return false;
       }
 
       entry.request_index   = it->second;
-      entry.type            = mapping.type;
-      entry.name_hash       = epee::string_tools::pod_to_hex(mapping.name_hash);
-      entry.value           = extract_lns_mapping_value(mapping);
-      entry.register_height = mapping.register_height;
-      entry.txid            = epee::string_tools::pod_to_hex(mapping.txid);
-      entry.prev_txid       = epee::string_tools::pod_to_hex(mapping.prev_txid);
+      entry.type            = record.type;
+      entry.name_hash       = epee::string_tools::pod_to_hex(record.name_hash);
+      entry.encrypted_value = epee::to_hex::string(epee::span<const uint8_t>(record.encrypted_value.buffer.data(), record.encrypted_value.len));
+      entry.register_height = record.register_height;
+      entry.txid            = epee::string_tools::pod_to_hex(record.txid);
+      entry.prev_txid       = epee::string_tools::pod_to_hex(record.prev_txid);
     }
 
     res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3445,7 +3445,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
       uint64_t entry_index;     // The index in request_entry's `entries` array that was resolved via Loki Name Service.
       uint16_t type;            // The type of Loki Name Service entry that the owner owns.
       std::string owner;        // The ed25519 public key that purchased the Loki Name Service entry.
-      std::string value;        // The value that the name maps to.
+      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
       uint64_t register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
       std::string txid;         // The txid of who purchased the mapping, null hash if not applicable.
       std::string prev_txid;    // The previous txid that purchased the mapping, null hash if not applicable.
@@ -3453,7 +3453,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
         KV_SERIALIZE(entry_index)
         KV_SERIALIZE(type)
         KV_SERIALIZE(owner)
-        KV_SERIALIZE(value)
+        KV_SERIALIZE(encrypted_value)
         KV_SERIALIZE(register_height)
         KV_SERIALIZE(txid)
         KV_SERIALIZE(prev_txid)
@@ -3491,14 +3491,15 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
       uint64_t    request_index;   // The index in request's `entries` array that was resolved via Loki Name Service.
       uint16_t    type;            // The category the Loki Name Service entry belongs to, currently only Session whose value is 0.
       std::string name_hash;       // The hash of the name that the owner purchased via Loki Name Service.
-      std::string value;           // The value that the name maps to.
+      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
       uint64_t    register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
       std::string txid;            // The txid of who purchases the mapping, null hash if not applicable
       std::string prev_txid;       // The previous txid that purchased the mapping, null hash if not applicable.
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(request_index)
         KV_SERIALIZE(type)
         KV_SERIALIZE(name_hash)
-        KV_SERIALIZE(value)
+        KV_SERIALIZE(encrypted_value)
         KV_SERIALIZE(register_height)
         KV_SERIALIZE(txid)
         KV_SERIALIZE(prev_txid)

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3424,7 +3424,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
     static size_t const MAX_TYPE_REQUEST_ENTRIES = 16;
     struct request_entry
     {
-      std::string name;            // The name to resolve to a public key via Loki Name Service
+      std::string name;            // The name to resolve to a mapping via Loki Name Service
       std::vector<uint16_t> types; // Set 0 for Session. In future updates more mapping types will be available.
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(name)
@@ -3490,14 +3490,14 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
     {
       uint64_t    request_index;   // The index in request's `entries` array that was resolved via Loki Name Service.
       uint16_t    type;            // The category the Loki Name Service entry belongs to, currently only Session whose value is 0.
-      std::string name;            // The name purchased via Loki Name Service
-      std::string value;           // The value that the name maps to
+      std::string name_hash;       // The hash of the name that the owner purchased via Loki Name Service.
+      std::string value;           // The value that the name maps to.
       uint64_t    register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
       std::string txid;            // The txid of who purchases the mapping, null hash if not applicable
       std::string prev_txid;       // The previous txid that purchased the mapping, null hash if not applicable.
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(type)
-        KV_SERIALIZE(name)
+        KV_SERIALIZE(name_hash)
         KV_SERIALIZE(value)
         KV_SERIALIZE(register_height)
         KV_SERIALIZE(txid)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -269,7 +269,7 @@ namespace
   const char* USAGE_REQUEST_STAKE_UNLOCK("request_stake_unlock <service_node_pubkey>");
   const char* USAGE_PRINT_LOCKED_STAKES("print_locked_stakes");
   const char* USAGE_BUY_LNS_MAPPING("buy_lns_mapping [index=<N1>[,<N2>,...]] [<priority>] [owner] \"<name>\" <value>");
-  const char* USAGE_PRINT_LNS_OWNERS_TO_NAMES("print_lns_owners_to_names [<64 hex character ed25519 public key>]");
+  const char* USAGE_PRINT_LNS_OWNERS_TO_NAMES_HASHES("print_lns_owners_to_names_hashes [<64 hex character ed25519 public key>]");
   const char* USAGE_PRINT_LNS_NAME_TO_OWNERS("print_lns_name_to_owners [type=<N1|all>[,<N2>...]] \"name\"");
 
 #if defined (LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
@@ -3231,7 +3231,7 @@ simple_wallet::simple_wallet()
 
   m_cmd_binder.set_handler("print_lns_owners_to_name_hashes",
                            boost::bind(&simple_wallet::print_lns_owners_to_name_hashes, this, _1),
-                           tr(USAGE_PRINT_LNS_OWNERS_TO_NAMES),
+                           tr(USAGE_PRINT_LNS_OWNERS_TO_NAMES_HASHES),
                            tr("Query the Loki Name Service names that the owners have purchased. If no keys are specified, it defaults to the current wallet."));
 
   m_cmd_binder.set_handler("print_lns_name_to_owners",
@@ -6761,7 +6761,7 @@ bool simple_wallet::print_lns_owners_to_name_hashes(const std::vector<std::strin
       }
     }
 
-    tools::msg_writer() << "owner=" << *owner << ", height=" << entry.register_height << ", name_hash=\"" << entry.name_hash << "\", value=" << entry.value << ", prev_txid=" << entry.prev_txid;
+    tools::msg_writer() << "owner=" << *owner << ", height=" << entry.register_height << ", name_hash=\"" << entry.name_hash << "\", encrypted_value=" << entry.encrypted_value << ", prev_txid=" << entry.prev_txid;
   }
   return true;
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3229,10 +3229,10 @@ simple_wallet::simple_wallet()
                            tr(USAGE_BUY_LNS_MAPPING),
                            tr(stream.str().c_str()));
 
-  m_cmd_binder.set_handler("print_lns_owners_to_names",
-                           boost::bind(&simple_wallet::print_lns_owners_to_names, this, _1),
+  m_cmd_binder.set_handler("print_lns_owners_to_name_hashes",
+                           boost::bind(&simple_wallet::print_lns_owners_to_name_hashes, this, _1),
                            tr(USAGE_PRINT_LNS_OWNERS_TO_NAMES),
-                           tr("Query the Loki Name Service names that the keys have purchased. If no keys are specified, it defaults to the current wallet."));
+                           tr("Query the Loki Name Service names that the owners have purchased. If no keys are specified, it defaults to the current wallet."));
 
   m_cmd_binder.set_handler("print_lns_name_to_owners",
                            boost::bind(&simple_wallet::print_lns_name_to_owners, this, _1),
@@ -6697,7 +6697,7 @@ bool simple_wallet::print_lns_name_to_owners(const std::vector<std::string>& arg
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::print_lns_owners_to_names(const std::vector<std::string>& args)
+bool simple_wallet::print_lns_owners_to_name_hashes(const std::vector<std::string>& args)
 {
   if (!try_connect_to_daemon())
     return false;
@@ -6761,7 +6761,7 @@ bool simple_wallet::print_lns_owners_to_names(const std::vector<std::string>& ar
       }
     }
 
-    tools::msg_writer() << "owner=" << *owner << ", height=" << entry.register_height << ", name=\"" << entry.name << "\", value=" << entry.value << ", prev_txid=" << entry.prev_txid;
+    tools::msg_writer() << "owner=" << *owner << ", height=" << entry.register_height << ", name_hash=\"" << entry.name_hash << "\", value=" << entry.value << ", prev_txid=" << entry.prev_txid;
   }
   return true;
 }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -178,7 +178,7 @@ namespace cryptonote
     bool print_locked_stakes(const std::vector<std::string>& /*args*/);
     bool query_locked_stakes(bool print_result);
     bool buy_lns_mapping(const std::vector<std::string> &args);
-    bool print_lns_owners_to_names(const std::vector<std::string> &args);
+    bool print_lns_owners_to_name_hashes(const std::vector<std::string> &args);
     bool print_lns_name_to_owners(const std::vector<std::string> &args);
 
     enum class sweep_type_t { stake, register_stake, all_or_below, single };

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -284,7 +284,7 @@ void loki_chain_generator::add_tx(cryptonote::transaction const &tx, bool can_be
 cryptonote::transaction
 loki_chain_generator::create_and_add_loki_name_system_tx(cryptonote::account_base const &src,
                                                           uint16_t type,
-                                                          std::string const &value,
+                                                          lns::mapping_value const &value,
                                                           std::string const &name,
                                                           crypto::ed25519_public_key const *owner,
                                                           bool kept_by_block)
@@ -502,7 +502,7 @@ cryptonote::checkpoint_t loki_chain_generator::create_service_node_checkpoint(ui
 
 cryptonote::transaction loki_chain_generator::create_loki_name_system_tx(cryptonote::account_base const &src,
                                                                          uint16_t type,
-                                                                         std::string const &value,
+                                                                         lns::mapping_value const &value,
                                                                          std::string const &name,
                                                                          crypto::ed25519_public_key const *owner,
                                                                          uint64_t burn) const
@@ -530,8 +530,12 @@ cryptonote::transaction loki_chain_generator::create_loki_name_system_tx(crypton
   if (lns::mapping_record mapping = lns_db_.get_mapping(type, name_hash))
     prev_txid = mapping.txid;
 
+  lns::mapping_value encrypted_value = {};
+  bool encrypted = lns::encrypt_mapping_value(name, value, encrypted_value);
+  assert(encrypted);
+
   std::vector<uint8_t> extra;
-  cryptonote::tx_extra_loki_name_system data(pkey, type, name_hash, value, prev_txid);
+  cryptonote::tx_extra_loki_name_system data(pkey, type, name_hash, encrypted_value.to_string(), prev_txid);
 
   cryptonote::add_loki_name_system_to_tx_extra(extra, data);
   cryptonote::add_burned_amount_to_tx_extra(extra, burn);

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1421,7 +1421,9 @@ struct loki_chain_generator
 
   // NOTE: Add constructed TX to events_ and assume that it is valid to add to the blockchain. If the TX is meant to be unaddable to the blockchain use the individual create + add functions to
   // be able to mark the add TX event as something that should trigger a failure.
-  cryptonote::transaction                              create_and_add_loki_name_system_tx(cryptonote::account_base const &src, uint16_t type, std::string const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, bool kept_by_block = false);
+
+  // value: The binary representation of the value part in the name->value mapping
+  cryptonote::transaction                              create_and_add_loki_name_system_tx(cryptonote::account_base const &src, uint16_t type, lns::mapping_value const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_tx                 (const cryptonote::account_base& src, const cryptonote::account_public_address& dest, uint64_t amount, uint64_t fee = TESTS_DEFAULT_FEE, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_state_change_tx(service_nodes::new_state state, const crypto::public_key& pub_key, uint64_t height = -1, const std::vector<uint64_t>& voters = {}, uint64_t fee = 0, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_registration_tx(const cryptonote::account_base& src, const cryptonote::keypair& sn_keys = cryptonote::keypair::generate(hw::get_device("default")), bool kept_by_block = false);
@@ -1442,7 +1444,7 @@ struct loki_chain_generator
 
   // value: Takes the binary value NOT the human readable version, of the name->value mapping
   static const uint64_t LNS_AUTO_BURN = static_cast<uint64_t>(-1);
-  cryptonote::transaction                              create_loki_name_system_tx    (cryptonote::account_base const &src, uint16_t type, std::string const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, uint64_t burn = LNS_AUTO_BURN) const;
+  cryptonote::transaction                              create_loki_name_system_tx(cryptonote::account_base const &src, uint16_t type, lns::mapping_value const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, uint64_t burn = LNS_AUTO_BURN) const;
 
   loki_blockchain_entry                                create_genesis_block(const cryptonote::account_base &miner, uint64_t timestamp);
   loki_blockchain_entry                                create_next_block(const std::vector<cryptonote::transaction>& txs = {}, cryptonote::checkpoint_t const *checkpoint = nullptr, uint64_t total_fee = 0);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1543,12 +1543,12 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     std::string name = "my_lns_name";
     cryptonote::tx_extra_loki_name_system valid_data = {};
     valid_data.owner                                 = miner_key.ed_key;
-    valid_data.type                                  = static_cast<uint16_t>(lns::mapping_type::wallet);
     valid_data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
     valid_data.name_hash                             = lns::name_to_hash("my_lns_name");
 
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
     {
+      valid_data.type = static_cast<uint16_t>(lns::mapping_type::wallet);
       // Blockchain name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
@@ -1557,13 +1557,19 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Empty wallet name in LNS is invalid");
       }
 
-      // Blockchain value (wallet address) is invalid, clearly too short
+      // Blockchain value (wallet address) is invalid, too short
       {
-        lns::mapping_value value = {};
-        value.len                = miner_key.wallet_value.len - 1;
-
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() - 1);
+        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet value in LNS too long");
+      }
+
+      // Blockchain value (wallet address) is invalid, too long
+      {
+        cryptonote::tx_extra_loki_name_system data = valid_data;
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() + 1);
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet value in LNS too long");
       }
     }
@@ -1582,44 +1588,38 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
 
       // Lokinet value too short
       {
-        lns::mapping_value value = {};
-        value.len                = miner_key.lokinet_value.len - 1;
-
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.lokinet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() - 1);
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too long");
       }
 
       // Lokinet value too long
       {
-        lns::mapping_value value                   = {};
-        value.len                                  = miner_key.lokinet_value.len + 1;
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.lokinet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() + 1);
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too long");
       }
     }
 
     // Session value too short
     // We added valid tx prior, we should update name to avoid conflict names in session land and test other invalid params
+    valid_data.type      = static_cast<uint16_t>(lns::mapping_type::session);
     name                 = "new_friendly_name";
     valid_data.name_hash = lns::name_to_hash(name);
     {
-      lns::mapping_value value = {};
-      value.len                = miner_key.session_value.len - 1;
-
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+      data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.session_value).to_string();
+      data.encrypted_value.resize(data.encrypted_value.size() - 1);
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too short");
     }
 
     // Session value too long
     {
-      lns::mapping_value value = {};
-      value.len                = miner_key.session_value.len - 1;
-
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+      data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.session_value).to_string();
+      data.encrypted_value.resize(data.encrypted_value.size() + 1);
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too long");
     }
 

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1635,41 +1635,6 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       data.name_hash                             = {};
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) Name empty");
     }
-
-    uint16_t custom_type = 1111;
-    if (lns::mapping_type_allowed(gen.hardfork(), custom_type))
-    {
-      cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.type                                  = custom_type;
-
-      // Generic name empty
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name_hash                             = {};
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
-      }
-
-      // Generic valid empty
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = {};
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Value empty");
-      }
-
-      // Generic name too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name_hash                             = lns::name_to_hash(std::string(lns::GENERIC_NAME_MAX + 1, 'A'));
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
-      }
-
-      // Generic value too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = std::string(lns::GENERIC_VALUE_MAX + 1, 'A');
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Value too long");
-      }
-    }
   }
   return true;
 }
@@ -2067,16 +2032,6 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
     data.value[1] = '5';
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
-
-  // Generic
-  if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet))
-  {
-    data.type       = 1111;
-    data.name_hash  = lns::name_to_hash(std::string(lns::GENERIC_NAME_MAX, 'A'));
-    data.value      = std::string(lns::GENERIC_VALUE_MAX, 'a');
-    make_lns_tx_with_custom_extra(gen, events, miner, data);
-  }
-
   return true;
 }
 

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1074,10 +1074,11 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
       CHECK_EQ(owner.id, 1);
       CHECK_EQ(miner_key.ed_key, owner.key);
 
-      lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name);
+      crypto::hash name_hash = lns::name_to_hash(name);
+      lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name_hash);
       CHECK_EQ(mappings.loaded, true);
       CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
-      CHECK_EQ(mappings.name, name);
+      CHECK_EQ(mappings.name_hash, name_hash);
       CHECK_EQ(mappings.value, miner_key.lokinet_value);
       CHECK_EQ(mappings.register_height, height_of_lns_entry);
       CHECK_EQ(mappings.owner_id, owner.id);
@@ -1098,11 +1099,12 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
       CHECK_EQ(owner.id, 1);
       CHECK_EQ(miner_key.ed_key, owner.key);
 
-      lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name);
+      crypto::hash name_hash = lns::name_to_hash(name);
+      lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name_hash);
       CHECK_EQ(mappings.loaded, true);
       CHECK_EQ(mappings.active(cryptonote::FAKECHAIN, blockchain_height), false);
       CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
-      CHECK_EQ(mappings.name, name);
+      CHECK_EQ(mappings.name_hash, name_hash);
       CHECK_EQ(mappings.value, miner_key.lokinet_value);
       CHECK_EQ(mappings.register_height, height_of_lns_entry);
       CHECK_EQ(mappings.owner_id, owner.id);
@@ -1186,8 +1188,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::session))
     {
-      CHECK_EQ(records[0].name, session_name1);
-      CHECK_EQ(records[1].name, session_name2);
+      CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
+      CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
       CHECK_EQ(records[0].register_height, session_height);
       CHECK_EQ(records[1].register_height, session_height);
       CHECK_EQ(records[0].value, bob_key.session_value);
@@ -1198,8 +1200,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::lokinet))
     {
-      CHECK_EQ(records[2].name, lokinet_name1);
-      CHECK_EQ(records[3].name, lokinet_name2);
+      CHECK_EQ(records[2].name_hash, lns::name_to_hash(lokinet_name1));
+      CHECK_EQ(records[3].name_hash, lns::name_to_hash(lokinet_name2));
       CHECK_EQ(records[2].register_height, lokinet_height);
       CHECK_EQ(records[3].register_height, lokinet_height);
       CHECK_EQ(records[2].value, bob_key.lokinet_value);
@@ -1210,8 +1212,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::wallet))
     {
-      CHECK_EQ(records[4].name, wallet_name1);
-      CHECK_EQ(records[5].name, wallet_name2);
+      CHECK_EQ(records[4].name_hash, lns::name_to_hash(wallet_name1));
+      CHECK_EQ(records[5].name_hash, lns::name_to_hash(wallet_name2));
       CHECK_EQ(records[4].register_height, wallet_height);
       CHECK_EQ(records[5].register_height, wallet_height);
       CHECK_EQ(records[4].value, bob_key.wallet_value);
@@ -1287,7 +1289,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
       return lhs.register_height < rhs.register_height;
     });
     CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
-    CHECK_EQ(records[0].name, session_name1);
+    CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
     CHECK_EQ(records[0].value, bob_key.session_value);
     CHECK_EQ(records[0].register_height, session_height1);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
@@ -1295,7 +1297,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     CHECK_EQ(records[0].owner, bob_key.ed_key);
 
     CHECK_EQ(records[1].type, static_cast<uint16_t>(lns::mapping_type::session));
-    CHECK_EQ(records[1].name, session_name2);
+    CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
     CHECK_EQ(records[1].value, bob_key.session_value);
     CHECK_EQ(records[1].register_height, session_height2);
     CHECK_EQ(records[1].prev_txid, crypto::null_hash);
@@ -1303,7 +1305,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     CHECK_EQ(records[1].owner, bob_key.ed_key);
 
     CHECK_EQ(records[2].type, static_cast<uint16_t>(lns::mapping_type::session));
-    CHECK_EQ(records[2].name, session_name3);
+    CHECK_EQ(records[2].name_hash, lns::name_to_hash(session_name3));
     CHECK_EQ(records[2].value, miner_key.session_value);
     CHECK_EQ(records[2].register_height, session_height3);
     CHECK_EQ(records[2].prev_txid, crypto::null_hash);
@@ -1348,10 +1350,12 @@ bool loki_name_system_get_mappings::generate(std::vector<test_event_entry> &even
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
     lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
-    std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name1);
+
+    crypto::hash session_name_hash = lns::name_to_hash(session_name1);
+    std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name_hash);
     CHECK_EQ(records.size(), 1);
     CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
-    CHECK_EQ(records[0].name, session_name1);
+    CHECK_EQ(records[0].name_hash, session_name_hash);
     CHECK_EQ(records[0].value, bob_key.session_value);
     CHECK_EQ(records[0].register_height, session_height);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
@@ -1421,20 +1425,21 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::session), session_name);
+    crypto::hash session_name_hash = lns::name_to_hash(session_name);
+    lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::session), session_name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::session));
-    CHECK_EQ(mappings.name, session_name);
+    CHECK_EQ(mappings.name_hash, session_name_hash);
     CHECK_EQ(mappings.value, bob_key.session_value);
     CHECK_EQ(mappings.register_height, height_of_lns_entry);
     CHECK_EQ(mappings.owner_id, owner.id);
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::lokinet))
     {
-      lns::mapping_record mappings2 = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), session_name);
+      lns::mapping_record mappings2 = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), session_name_hash);
       CHECK_EQ(mappings2.loaded, true);
       CHECK_EQ(mappings2.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
-      CHECK_EQ(mappings2.name, session_name);
+      CHECK_EQ(mappings2.name_hash, session_name_hash);
       CHECK_EQ(mappings2.value, miner_key.lokinet_value);
       CHECK_EQ(mappings2.register_height, height_of_lns_entry);
       CHECK_EQ(mappings2.owner_id, owner.id);
@@ -1442,10 +1447,10 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), custom_type))
     {
-      lns::mapping_record mappings3 = lns_db.get_mapping(custom_type, session_name);
+      lns::mapping_record mappings3 = lns_db.get_mapping(custom_type, session_name_hash);
       CHECK_EQ(mappings3.loaded, true);
       CHECK_EQ(mappings3.type, custom_type);
-      CHECK_EQ(mappings3.name, session_name);
+      CHECK_EQ(mappings3.name_hash, session_name_hash);
       CHECK_EQ(mappings3.value, bob_key.session_value);
       CHECK_EQ(mappings3.register_height, height_of_lns_entry);
       CHECK_EQ(mappings3.owner_id, owner.id);
@@ -1537,21 +1542,14 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     valid_data.owner                                 = miner_key.ed_key;
     valid_data.type                                  = static_cast<uint16_t>(lns::mapping_type::wallet);
     valid_data.value                                 = miner_key.wallet_value;
-    valid_data.name                                  = "my_lns_name";
+    valid_data.name_hash                             = lns::name_to_hash("my_lns_name");
 
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
     {
-      // Blockchain name too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = std::string(lns::WALLET_NAME_MAX + 1, 'A');
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet to name in LNS too long");
-      }
-
       // Blockchain name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = {};
+        data.name_hash                             = {};
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Empty wallet name in LNS is invalid");
       }
 
@@ -1566,18 +1564,10 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet))
     {
       valid_data.type = static_cast<uint16_t>(lns::mapping_type::lokinet);
-      // Lokinet domain name too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = std::string(lns::LOKINET_DOMAIN_NAME_MAX, 'A');
-        data.name                                 += ".loki";
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain name in LNS too long");
-      }
-
       // Lokinet domain name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = {};
+        data.name_hash                             = {};
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Empty domain name in LNS is invalid");
       }
 
@@ -1625,7 +1615,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
 
     // Session value too short
     // We added valid tx prior, we should update name to avoid conflict names in session land and test other invalid params
-    valid_data.name = "new_friendly_name";
+    valid_data.name_hash = lns::name_to_hash("new_friendly_name");
     {
       cryptonote::tx_extra_loki_name_system data = valid_data;
       data.value                                 = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH * 2 - 1, 'A');
@@ -1639,18 +1629,11 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too long");
     }
 
-    // Session name too long
-    {
-      cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.name                                  = std::string(lns::SESSION_DISPLAY_NAME_MAX + 1, 'A');
-      make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, name too long");
-    }
-
     // Session name empty
     {
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.name                                  = {};
-      make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, name too long");
+      data.name_hash                             = {};
+      make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) Name empty");
     }
 
     uint16_t custom_type = 1111;
@@ -1662,7 +1645,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       // Generic name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = {};
+        data.name_hash                             = {};
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
       }
 
@@ -1676,7 +1659,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       // Generic name too long
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = std::string(lns::GENERIC_NAME_MAX + 1, 'A');
+        data.name_hash                             = lns::name_to_hash(std::string(lns::GENERIC_NAME_MAX + 1, 'A'));
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
       }
 
@@ -1761,19 +1744,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         if (record.type == static_cast<uint16_t>(lns::mapping_type::session))
         {
-          CHECK_EQ(record.name, miner_session_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.session_value);
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::lokinet))
         {
-          CHECK_EQ(record.name, miner_lokinet_domain1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.lokinet_value);
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::wallet))
         {
-          CHECK_EQ(record.name, miner_wallet_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.wallet_value);
         }
@@ -1819,19 +1802,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
         {
           if (record.type == static_cast<uint16_t>(lns::mapping_type::session))
           {
-            CHECK_EQ(record.name, miner_session_name1);
+            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
             CHECK_EQ(record.register_height, first_lns_height);
             CHECK_EQ(record.value, miner_key.session_value);
           }
           else if (record.type == static_cast<uint16_t>(lns::mapping_type::lokinet))
           {
-            CHECK_EQ(record.name, miner_lokinet_domain1);
+            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
             CHECK_EQ(record.register_height, second_lns_height);
             CHECK_EQ(record.value, miner_key.lokinet_value);
           }
           else if (record.type == static_cast<uint16_t>(lns::mapping_type::wallet))
           {
-            CHECK_EQ(record.name, miner_wallet_name1);
+            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
             CHECK_EQ(record.register_height, first_lns_height);
             CHECK_EQ(record.value, miner_key.wallet_value);
           }
@@ -1846,7 +1829,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         std::vector<lns::mapping_record> records = lns_db.get_mappings_by_owner(bob_key.ed_key);
         CHECK_EQ(records.size(), 1);
-        CHECK_EQ(records[0].name, bob_session_name1);
+        CHECK_EQ(records[0].name_hash, lns::name_to_hash(bob_session_name1));
         CHECK_EQ(records[0].register_height, second_lns_height);
         CHECK_EQ(records[0].value, bob_key.session_value);
         CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
@@ -1888,19 +1871,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         if (record.type == static_cast<uint16_t>(lns::mapping_type::session))
         {
-          CHECK_EQ(record.name, miner_session_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.session_value);
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::lokinet))
         {
-          CHECK_EQ(record.name, miner_lokinet_domain1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.lokinet_value);
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::wallet))
         {
-          CHECK_EQ(record.name, miner_wallet_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.wallet_value);
         }
@@ -1974,10 +1957,11 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name);
+    crypto::hash name_hash = lns::name_to_hash(name);
+    lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
-    CHECK_EQ(mappings.name, name);
+    CHECK_EQ(mappings.name_hash, name_hash);
     CHECK_EQ(mappings.value, miner_key.lokinet_value);
     CHECK_EQ(mappings.register_height, height_of_lns_entry);
     CHECK_EQ(mappings.prev_txid, crypto::null_hash);
@@ -2003,10 +1987,11 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name);
+    crypto::hash name_hash = lns::name_to_hash(name);
+    lns::mapping_record mappings = lns_db.get_mapping(static_cast<uint16_t>(lns::mapping_type::lokinet), name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
-    CHECK_EQ(mappings.name, name);
+    CHECK_EQ(mappings.name_hash, name_hash);
     CHECK_EQ(mappings.value, miner_key.lokinet_value);
     CHECK_EQ(mappings.register_height, renewal_height);
     CHECK_EQ(mappings.prev_txid, prev_txid);
@@ -2059,7 +2044,7 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
   {
     data.type                                  = static_cast<uint16_t>(lns::mapping_type::wallet);
-    data.name                                  = std::string(lns::WALLET_NAME_MAX, 'A');
+    data.name_hash                             = lns::name_to_hash(std::string(lns::WALLET_NAME_MAX, 'A'));
     data.value                                 = miner_key.wallet_value;
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
@@ -2068,7 +2053,7 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet))
   {
     data.type                                  = static_cast<uint16_t>(lns::mapping_type::lokinet);
-    data.name                                  = "doyle.loki";
+    data.name_hash                             = lns::name_to_hash("doyle.loki");
     data.value                                 = std::string(lns::LOKINET_ADDRESS_BINARY_LENGTH, 'a');
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
@@ -2076,7 +2061,7 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   // Session
   {
     data.type     = static_cast<uint16_t>(lns::mapping_type::session);
-    data.name     = std::string(lns::SESSION_DISPLAY_NAME_MAX, 'A');
+    data.name_hash= lns::name_to_hash(std::string(lns::SESSION_DISPLAY_NAME_MAX, 'A'));
     data.value    = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH, 'a');
     data.value[0] = '0';
     data.value[1] = '5';
@@ -2086,9 +2071,9 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   // Generic
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet))
   {
-    data.type  = 1111;
-    data.name  = std::string(lns::GENERIC_NAME_MAX, 'A');
-    data.value = std::string(lns::GENERIC_VALUE_MAX, 'a');
+    data.type       = 1111;
+    data.name_hash  = lns::name_to_hash(std::string(lns::GENERIC_NAME_MAX, 'A'));
+    data.value      = std::string(lns::GENERIC_VALUE_MAX, 'a');
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
 
@@ -2169,7 +2154,7 @@ bool loki_name_system_wrong_version::generate(std::vector<test_event_entry> &eve
   data.owner                                 = miner_key.ed_key;
   data.type                                  = static_cast<uint16_t>(lns::mapping_type::session);
   data.value                                 = miner_key.session_value;
-  data.name                                  = "my_lns_name";
+  data.name_hash                             = lns::name_to_hash("my_lns_name");
 
   uint64_t new_height       = cryptonote::get_block_height(gen.top().block) + 1;
   uint8_t new_hf_version    = gen.get_hf_version_at(new_height);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1002,7 +1002,8 @@ bool loki_name_system_disallow_reserved_type::generate(std::vector<test_event_en
   gen.add_n_blocks(10); /// generate some outputs and unlock them
   gen.add_mined_money_unlock_blocks();
 
-  std::string mapping_value = "asdf";
+  lns::mapping_value mapping_value = {};
+  mapping_value.len                = 20;
 
   auto unusable_type = static_cast<uint16_t>(-1);
   assert(!lns::mapping_type_allowed(gen.hardfork(), unusable_type));
@@ -1015,13 +1016,9 @@ struct lns_keys_t
 {
   crypto::ed25519_public_key ed_key;
   crypto::ed25519_secret_key ed_skey;
-  std::string                wallet_value; // NOTE: this field is the binary (value) part of the name -> (value) mapping
-  std::string                lokinet_value;
-  std::string                session_value;
-
-  std::string                session_value_hex; // NOTE: likewise, but represented in hex, except, for blockchain, which is the cryptonote account address
-  std::string                wallet_value_hex;
-  std::string                lokinet_value_hex;
+  lns::mapping_value         wallet_value; // NOTE: this field is the binary (value) part of the name -> (value) mapping
+  lns::mapping_value         lokinet_value;
+  lns::mapping_value         session_value;
 };
 
 static lns_keys_t make_lns_keys(cryptonote::account_base const &src)
@@ -1029,20 +1026,25 @@ static lns_keys_t make_lns_keys(cryptonote::account_base const &src)
   lns_keys_t result = {};
   crypto_sign_ed25519_seed_keypair(result.ed_key.data, result.ed_skey.data, reinterpret_cast<const unsigned char *>(src.get_keys().m_spend_secret_key.data));
 
-  char session_value[lns::SESSION_PUBLIC_KEY_BINARY_LENGTH] = {};
-  session_value[0]                                            = 5; // prefix with 0x05
-  memcpy(session_value + 1, &result.ed_key, sizeof(result.ed_key));
+  result.session_value.len = lns::SESSION_PUBLIC_KEY_BINARY_LENGTH;
+  result.wallet_value.len  = sizeof(src.get_keys().m_account_address);
+  result.lokinet_value.len = sizeof(result.ed_key.data);
 
-  result.session_value  = std::string(session_value, sizeof(session_value));
-  result.wallet_value = std::string((char *)&src.get_keys().m_account_address, sizeof(src.get_keys().m_account_address));
-  result.lokinet_value    = std::string((char *)result.ed_key.data, sizeof(result.ed_key.data));
+  memcpy(&result.session_value.buffer[0], &result.ed_key, sizeof(result.ed_key));
+  memcpy(&result.wallet_value.buffer[0], (char *)&src.get_keys().m_account_address, result.wallet_value.len);
+  memcpy(&result.lokinet_value.buffer[0], (char *)result.ed_key.data, result.lokinet_value.len);
 
-  result.session_value_hex  = epee::string_tools::pod_to_hex(session_value);
-  result.wallet_value_hex = cryptonote::get_account_address_as_str(cryptonote::FAKECHAIN, false /*subaddress*/, src.get_keys().m_account_address);
-  result.lokinet_value_hex    = epee::string_tools::pod_to_hex(result.ed_key);
+  result.session_value.buffer[0] = 5; // prefix with 0x05
   return result;
 }
 
+static lns::mapping_value helper_encrypt_lns_value(std::string const &name, lns::mapping_value const &value)
+{
+  lns::mapping_value result;
+  bool encrypted = lns::encrypt_mapping_value(name, value, result);
+  assert(encrypted);
+  return result;
+}
 
 bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events)
 {
@@ -1079,7 +1081,7 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
       CHECK_EQ(mappings.loaded, true);
       CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
       CHECK_EQ(mappings.name_hash, name_hash);
-      CHECK_EQ(mappings.value, miner_key.lokinet_value);
+      CHECK_EQ(mappings.encrypted_value, helper_encrypt_lns_value(name, miner_key.lokinet_value));
       CHECK_EQ(mappings.register_height, height_of_lns_entry);
       CHECK_EQ(mappings.owner_id, owner.id);
       return true;
@@ -1105,7 +1107,7 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
       CHECK_EQ(mappings.active(cryptonote::FAKECHAIN, blockchain_height), false);
       CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
       CHECK_EQ(mappings.name_hash, name_hash);
-      CHECK_EQ(mappings.value, miner_key.lokinet_value);
+      CHECK_EQ(mappings.encrypted_value, helper_encrypt_lns_value(name, miner_key.lokinet_value));
       CHECK_EQ(mappings.register_height, height_of_lns_entry);
       CHECK_EQ(mappings.owner_id, owner.id);
       return true;
@@ -1192,8 +1194,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
       CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
       CHECK_EQ(records[0].register_height, session_height);
       CHECK_EQ(records[1].register_height, session_height);
-      CHECK_EQ(records[0].value, bob_key.session_value);
-      CHECK_EQ(records[1].value, bob_key.session_value);
+      CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(session_name1, bob_key.session_value));
+      CHECK_EQ(records[1].encrypted_value, helper_encrypt_lns_value(session_name2, bob_key.session_value));
       CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
       CHECK_EQ(records[1].type, static_cast<uint16_t>(lns::mapping_type::session));
     }
@@ -1204,8 +1206,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
       CHECK_EQ(records[3].name_hash, lns::name_to_hash(lokinet_name2));
       CHECK_EQ(records[2].register_height, lokinet_height);
       CHECK_EQ(records[3].register_height, lokinet_height);
-      CHECK_EQ(records[2].value, bob_key.lokinet_value);
-      CHECK_EQ(records[3].value, bob_key.lokinet_value);
+      CHECK_EQ(records[2].encrypted_value, helper_encrypt_lns_value(lokinet_name1, bob_key.lokinet_value));
+      CHECK_EQ(records[3].encrypted_value, helper_encrypt_lns_value(lokinet_name2, bob_key.lokinet_value));
       CHECK_EQ(records[2].type, static_cast<uint16_t>(lns::mapping_type::lokinet));
       CHECK_EQ(records[3].type, static_cast<uint16_t>(lns::mapping_type::lokinet));
     }
@@ -1216,8 +1218,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
       CHECK_EQ(records[5].name_hash, lns::name_to_hash(wallet_name2));
       CHECK_EQ(records[4].register_height, wallet_height);
       CHECK_EQ(records[5].register_height, wallet_height);
-      CHECK_EQ(records[4].value, bob_key.wallet_value);
-      CHECK_EQ(records[5].value, bob_key.wallet_value);
+      CHECK_EQ(records[4].encrypted_value, helper_encrypt_lns_value(wallet_name1, bob_key.wallet_value));
+      CHECK_EQ(records[5].encrypted_value, helper_encrypt_lns_value(wallet_name2, bob_key.wallet_value));
       CHECK_EQ(records[4].type, static_cast<uint16_t>(lns::mapping_type::wallet));
       CHECK_EQ(records[5].type, static_cast<uint16_t>(lns::mapping_type::wallet));
     }
@@ -1290,7 +1292,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     });
     CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
     CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
-    CHECK_EQ(records[0].value, bob_key.session_value);
+    CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(session_name1, bob_key.session_value));
     CHECK_EQ(records[0].register_height, session_height1);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
     CHECK_EQ(records[0].txid, session_tx_hash1);
@@ -1298,7 +1300,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
 
     CHECK_EQ(records[1].type, static_cast<uint16_t>(lns::mapping_type::session));
     CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
-    CHECK_EQ(records[1].value, bob_key.session_value);
+    CHECK_EQ(records[1].encrypted_value, helper_encrypt_lns_value(session_name2, bob_key.session_value));
     CHECK_EQ(records[1].register_height, session_height2);
     CHECK_EQ(records[1].prev_txid, crypto::null_hash);
     CHECK_EQ(records[1].txid, session_tx_hash2);
@@ -1306,7 +1308,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
 
     CHECK_EQ(records[2].type, static_cast<uint16_t>(lns::mapping_type::session));
     CHECK_EQ(records[2].name_hash, lns::name_to_hash(session_name3));
-    CHECK_EQ(records[2].value, miner_key.session_value);
+    CHECK_EQ(records[2].encrypted_value, helper_encrypt_lns_value(session_name3, miner_key.session_value));
     CHECK_EQ(records[2].register_height, session_height3);
     CHECK_EQ(records[2].prev_txid, crypto::null_hash);
     CHECK_EQ(records[2].txid, session_tx_hash3);
@@ -1356,7 +1358,7 @@ bool loki_name_system_get_mappings::generate(std::vector<test_event_entry> &even
     CHECK_EQ(records.size(), 1);
     CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
     CHECK_EQ(records[0].name_hash, session_name_hash);
-    CHECK_EQ(records[0].value, bob_key.session_value);
+    CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(session_name1, bob_key.session_value));
     CHECK_EQ(records[0].register_height, session_height);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
     CHECK_EQ(records[0].txid, session_tx_hash);
@@ -1430,7 +1432,7 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::session));
     CHECK_EQ(mappings.name_hash, session_name_hash);
-    CHECK_EQ(mappings.value, bob_key.session_value);
+    CHECK_EQ(mappings.encrypted_value, helper_encrypt_lns_value(session_name, bob_key.session_value));
     CHECK_EQ(mappings.register_height, height_of_lns_entry);
     CHECK_EQ(mappings.owner_id, owner.id);
 
@@ -1440,7 +1442,7 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
       CHECK_EQ(mappings2.loaded, true);
       CHECK_EQ(mappings2.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
       CHECK_EQ(mappings2.name_hash, session_name_hash);
-      CHECK_EQ(mappings2.value, miner_key.lokinet_value);
+      CHECK_EQ(mappings2.encrypted_value, helper_encrypt_lns_value(session_name, miner_key.lokinet_value));
       CHECK_EQ(mappings2.register_height, height_of_lns_entry);
       CHECK_EQ(mappings2.owner_id, owner.id);
     }
@@ -1451,7 +1453,7 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
       CHECK_EQ(mappings3.loaded, true);
       CHECK_EQ(mappings3.type, custom_type);
       CHECK_EQ(mappings3.name_hash, session_name_hash);
-      CHECK_EQ(mappings3.value, bob_key.session_value);
+      CHECK_EQ(mappings3.encrypted_value, helper_encrypt_lns_value(session_name, bob_key.session_value));
       CHECK_EQ(mappings3.register_height, height_of_lns_entry);
       CHECK_EQ(mappings3.owner_id, owner.id);
     }
@@ -1538,10 +1540,11 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       gen.add_tx(tx, valid /*can_be_added_to_blockchain*/, reason, false /*kept_by_block*/);
     };
 
+    std::string name = "my_lns_name";
     cryptonote::tx_extra_loki_name_system valid_data = {};
     valid_data.owner                                 = miner_key.ed_key;
     valid_data.type                                  = static_cast<uint16_t>(lns::mapping_type::wallet);
-    valid_data.value                                 = miner_key.wallet_value;
+    valid_data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
     valid_data.name_hash                             = lns::name_to_hash("my_lns_name");
 
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
@@ -1550,13 +1553,17 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
         data.name_hash                             = {};
+        data.encrypted_value                       = helper_encrypt_lns_value("", miner_key.wallet_value).to_string();
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Empty wallet name in LNS is invalid");
       }
 
       // Blockchain value (wallet address) is invalid, clearly too short
       {
+        lns::mapping_value value = {};
+        value.len                = miner_key.wallet_value.len - 1;
+
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = std::string(32, 'A');
+        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet value in LNS too long");
       }
     }
@@ -1564,68 +1571,55 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet))
     {
       valid_data.type = static_cast<uint16_t>(lns::mapping_type::lokinet);
-      // Lokinet domain name empty
+
+      // Lokinet name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
         data.name_hash                             = {};
+        data.encrypted_value                       = helper_encrypt_lns_value("", miner_key.lokinet_value).to_string();
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Empty domain name in LNS is invalid");
       }
 
-      // Lokinet domain value too long
+      // Lokinet value too short
       {
+        lns::mapping_value value = {};
+        value.len                = miner_key.lokinet_value.len - 1;
+
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = std::string(lns::LOKINET_ADDRESS_BINARY_LENGTH * 2 + 1, 'A');
+        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too long");
       }
 
-      // Lokinet domain value too long
+      // Lokinet value too long
       {
+        lns::mapping_value value                   = {};
+        value.len                                  = miner_key.lokinet_value.len + 1;
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = std::string(lns::LOKINET_ADDRESS_BINARY_LENGTH * 2 - 1, 'A');
-
-        size_t index                            = 0;
-        data.value[data.value.size() - ++index] = 'i';
-        data.value[data.value.size() - ++index] = 'k';
-        data.value[data.value.size() - ++index] = 'o';
-        data.value[data.value.size() - ++index] = 'l';
-        data.value[data.value.size() - ++index] = '.';
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too short");
+        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too long");
       }
-    }
-
-    // Session value invalid, session keys require a 33 byte key where the first byte is a 0x05
-    std::stringstream stream;
-    valid_data.type  = static_cast<uint16_t>(lns::mapping_type::session);
-    {
-      cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.value[0]                              = 'a';
-      stream << "(Session) Key invalid, not prefixed with 0x05";
-      make_lns_tx_with_custom_extra(gen, events, miner, data, false, stream.str().c_str());
-      stream.clear();
-    }
-
-    // Session should be valid with this key with a 0x05 prefix
-    valid_data.value = miner_key.session_value;
-    {
-      cryptonote::tx_extra_loki_name_system data = valid_data;
-      stream << "(Session) Key should be valid, prefixed with 0x05: " << miner_key.session_value_hex;
-      make_lns_tx_with_custom_extra(gen, events, miner, data, true, stream.str().c_str());
-      stream.clear();
     }
 
     // Session value too short
     // We added valid tx prior, we should update name to avoid conflict names in session land and test other invalid params
-    valid_data.name_hash = lns::name_to_hash("new_friendly_name");
+    name                 = "new_friendly_name";
+    valid_data.name_hash = lns::name_to_hash(name);
     {
+      lns::mapping_value value = {};
+      value.len                = miner_key.session_value.len - 1;
+
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.value                                 = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH * 2 - 1, 'A');
+      data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too short");
     }
 
     // Session value too long
     {
+      lns::mapping_value value = {};
+      value.len                = miner_key.session_value.len - 1;
+
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.value                                 = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH * 2 + 1, 'A');
+      data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too long");
     }
 
@@ -1633,6 +1627,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     {
       cryptonote::tx_extra_loki_name_system data = valid_data;
       data.name_hash                             = {};
+      data.encrypted_value                       = helper_encrypt_lns_value("", miner_key.session_value).to_string();
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) Name empty");
     }
   }
@@ -1711,19 +1706,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
         {
           CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
-          CHECK_EQ(record.value, miner_key.session_value);
+          CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_session_name1, miner_key.session_value));
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::lokinet))
         {
           CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
-          CHECK_EQ(record.value, miner_key.lokinet_value);
+          CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_lokinet_domain1, miner_key.lokinet_value));
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::wallet))
         {
           CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
-          CHECK_EQ(record.value, miner_key.wallet_value);
+          CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_wallet_name1, miner_key.wallet_value));
         }
         else
         {
@@ -1769,19 +1764,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
           {
             CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
             CHECK_EQ(record.register_height, first_lns_height);
-            CHECK_EQ(record.value, miner_key.session_value);
+            CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_session_name1, miner_key.session_value));
           }
           else if (record.type == static_cast<uint16_t>(lns::mapping_type::lokinet))
           {
             CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
             CHECK_EQ(record.register_height, second_lns_height);
-            CHECK_EQ(record.value, miner_key.lokinet_value);
+            CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_lokinet_domain1, miner_key.lokinet_value));
           }
           else if (record.type == static_cast<uint16_t>(lns::mapping_type::wallet))
           {
             CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
             CHECK_EQ(record.register_height, first_lns_height);
-            CHECK_EQ(record.value, miner_key.wallet_value);
+            CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_wallet_name1, miner_key.wallet_value));
           }
           else
           {
@@ -1796,7 +1791,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
         CHECK_EQ(records.size(), 1);
         CHECK_EQ(records[0].name_hash, lns::name_to_hash(bob_session_name1));
         CHECK_EQ(records[0].register_height, second_lns_height);
-        CHECK_EQ(records[0].value, bob_key.session_value);
+        CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(bob_session_name1, bob_key.session_value));
         CHECK_EQ(records[0].type, static_cast<uint16_t>(lns::mapping_type::session));
       }
 
@@ -1838,19 +1833,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
         {
           CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
-          CHECK_EQ(record.value, miner_key.session_value);
+          CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_session_name1, miner_key.session_value));
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::lokinet))
         {
           CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
-          CHECK_EQ(record.value, miner_key.lokinet_value);
+          CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_lokinet_domain1, miner_key.lokinet_value));
         }
         else if (record.type == static_cast<uint16_t>(lns::mapping_type::wallet))
         {
           CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
-          CHECK_EQ(record.value, miner_key.wallet_value);
+          CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_wallet_name1, miner_key.wallet_value));
         }
         else
         {
@@ -1927,7 +1922,7 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
     CHECK_EQ(mappings.name_hash, name_hash);
-    CHECK_EQ(mappings.value, miner_key.lokinet_value);
+    CHECK_EQ(mappings.encrypted_value, helper_encrypt_lns_value(name, miner_key.lokinet_value));
     CHECK_EQ(mappings.register_height, height_of_lns_entry);
     CHECK_EQ(mappings.prev_txid, crypto::null_hash);
     CHECK_EQ(mappings.owner_id, owner.id);
@@ -1957,7 +1952,7 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, static_cast<uint16_t>(lns::mapping_type::lokinet));
     CHECK_EQ(mappings.name_hash, name_hash);
-    CHECK_EQ(mappings.value, miner_key.lokinet_value);
+    CHECK_EQ(mappings.encrypted_value, helper_encrypt_lns_value(name, miner_key.lokinet_value));
     CHECK_EQ(mappings.register_height, renewal_height);
     CHECK_EQ(mappings.prev_txid, prev_txid);
     CHECK_EQ(mappings.owner_id, owner.id);
@@ -2005,31 +2000,40 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   cryptonote::tx_extra_loki_name_system data = {};
   data.owner                                 = miner_key.ed_key;
 
-  // Blockchain
+  // Wallet
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
   {
-    data.type                                  = static_cast<uint16_t>(lns::mapping_type::wallet);
-    data.name_hash                             = lns::name_to_hash(std::string(lns::WALLET_NAME_MAX, 'A'));
-    data.value                                 = miner_key.wallet_value;
+    std::string name(lns::WALLET_NAME_MAX, 'A');
+    data.type            = static_cast<uint16_t>(lns::mapping_type::wallet);
+    data.name_hash       = lns::name_to_hash(name);
+    data.encrypted_value = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
 
   // Lokinet
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet))
   {
-    data.type                                  = static_cast<uint16_t>(lns::mapping_type::lokinet);
-    data.name_hash                             = lns::name_to_hash("doyle.loki");
-    data.value                                 = std::string(lns::LOKINET_ADDRESS_BINARY_LENGTH, 'a');
+    std::string name(lns::LOKINET_DOMAIN_NAME_MAX, 'A');
+    size_t last_index  = name.size() - 1;
+    name[last_index--] = 'i';
+    name[last_index--] = 'k';
+    name[last_index--] = 'o';
+    name[last_index--] = 'l';
+    name[last_index--] = '.';
+
+    data.type            = static_cast<uint16_t>(lns::mapping_type::lokinet);
+    data.name_hash       = lns::name_to_hash(name);
+    data.encrypted_value = helper_encrypt_lns_value(name, miner_key.lokinet_value).to_string();
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
 
   // Session
   {
+    std::string name(lns::SESSION_DISPLAY_NAME_MAX, 'A');
+
     data.type     = static_cast<uint16_t>(lns::mapping_type::session);
-    data.name_hash= lns::name_to_hash(std::string(lns::SESSION_DISPLAY_NAME_MAX, 'A'));
-    data.value    = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH, 'a');
-    data.value[0] = '0';
-    data.value[1] = '5';
+    data.name_hash = lns::name_to_hash(name);
+    data.encrypted_value = helper_encrypt_lns_value(name, miner_key.session_value).to_string();
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
   return true;
@@ -2057,7 +2061,7 @@ bool loki_name_system_wrong_burn::generate(std::vector<test_event_entry> &events
     {
       if (lns::mapping_type_allowed(gen.hardfork(), type))
       {
-        std::string value;
+        lns::mapping_value value = {};
         std::string name;
 
         if (type == lns::mapping_type::session)
@@ -2103,13 +2107,14 @@ bool loki_name_system_wrong_version::generate(std::vector<test_event_entry> &eve
   gen.add_n_blocks(10); /// generate some outputs and unlock them
   gen.add_mined_money_unlock_blocks();
 
+  std::string name = "lns_name";
   lns_keys_t miner_key                       = make_lns_keys(miner);
   cryptonote::tx_extra_loki_name_system data = {};
   data.version                               = 0xFF;
   data.owner                                 = miner_key.ed_key;
   data.type                                  = static_cast<uint16_t>(lns::mapping_type::session);
-  data.value                                 = miner_key.session_value;
-  data.name_hash                             = lns::name_to_hash("my_lns_name");
+  data.name_hash                             = lns::name_to_hash(name);
+  data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.session_value).to_string();
 
   uint64_t new_height       = cryptonote::get_block_height(gen.top().block) + 1;
   uint8_t new_hf_version    = gen.get_hf_version_at(new_height);

--- a/tests/unit_tests/loki_name_system.cpp
+++ b/tests/unit_tests/loki_name_system.cpp
@@ -62,3 +62,41 @@ TEST(loki_name_system, lokinet_domain_names)
     ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
   }
 }
+
+TEST(loki_name_system, value_encrypt_and_decrypt)
+{
+  std::string name         = "my lns name";
+  lns::mapping_value value = {};
+  value.len                = 32;
+  memset(&value.buffer[0], 'a', value.len);
+
+  // Encryption and Decryption success
+  {
+    lns::mapping_value encrypted_value = {};
+    lns::mapping_value decrypted_value = {};
+    ASSERT_TRUE(lns::encrypt_mapping_value(name, value, encrypted_value));
+    ASSERT_TRUE(lns::decrypt_mapping_value(name, encrypted_value, decrypted_value));
+    ASSERT_TRUE(value == decrypted_value);
+  }
+
+  // Decryption Fail: Encrypted value was modified
+  {
+    lns::mapping_value encrypted_value = {};
+    ASSERT_TRUE(lns::encrypt_mapping_value(name, value, encrypted_value));
+
+    encrypted_value.buffer[0] = 'Z';
+    lns::mapping_value decrypted_value;
+    ASSERT_FALSE(lns::decrypt_mapping_value(name, encrypted_value, decrypted_value));
+  }
+
+  // Decryption Fail: Name was modified
+  {
+    std::string name_copy = name;
+    lns::mapping_value encrypted_value = {};
+    ASSERT_TRUE(lns::encrypt_mapping_value(name_copy, value, encrypted_value));
+
+    name_copy[0] = 'Z';
+    lns::mapping_value decrypted_value;
+    ASSERT_FALSE(lns::decrypt_mapping_value(name_copy, encrypted_value, decrypted_value));
+  }
+}


### PR DESCRIPTION
> 
> This structure is going to allow enumeration in a few different ways which I think we can avoid.  First it makes it super easy for anyone with the blockchain to see that "jason.loki" has been registered by just looking at the registration.  I think we can feasibly blind them:
> 
> - instead of storing `name` we would store `name_hash`.  Anyone who has the name already can get this, but some rando watching the blockchain would have to use a dictionary attack (and even then can't identify everything, e.g. `omgcatsareawesome.loki` isn't going to be decipherable).  We probably want that hash to be moderately expensive so that a dictionary attack is hard.
> - Encrypt `value` using the name as the secret.  This prevents correlation between registrations: if I have two opaque records that I don't know the name of, I can't tell that they are two registrations going to the same .loki address (or wallet or whatever).
> 
> The second problem is with the `owner` pubkey: since this is unique per wallet, I can instantly connect all registrations from the same wallet together.  We can fix that, too, if we use distinct keys for each registration.  (We would still want them to be determined from the wallet, but there are ways to do something along the lines of BIP32 to generate derivative keys).
>
> (I think this should be left for a later commit rather than addressed in this PR, however).

https://github.com/loki-project/loki-core/pull/922#discussion_r371468122

This implements the first 2 bullet points, and updates the following RPC output

```
  LOKI_RPC_DOC_INTROSPECT
  // Get the name mapping for a Loki Name Service entry. Loki currently supports mappings
  // for Session.
  struct COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS
  {
    ...
    struct response_entry
    {
      uint64_t entry_index;     // The index in request_entry's `entries` array that was resolved via Loki Name Service.
      uint16_t type;            // The type of Loki Name Service entry that the owner owns.
      std::string owner;        // The ed25519 public key that purchased the Loki Name Service entry.
      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
      uint64_t register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
      std::string txid;         // The txid of who purchased the mapping, null hash if not applicable.
      std::string prev_txid;    // The previous txid that purchased the mapping, null hash if not applicable.
    };

    struct response
    {
      std::vector<response_entry> entries;
      std::string status; // Generic RPC error code. "OK" is the success value.
    };
  };

  LOKI_RPC_DOC_INTROSPECT
  // Get all the name mappings for the queried owner. The owner should be
  // a ed25519 public key; by default this is the public key of an ed25519
  // keypair derived using the wallet's secret spend key as the seed value.
  struct COMMAND_RPC_GET_LNS_OWNERS_TO_NAMES
  {
    ...
    struct response_entry
    {
      uint64_t    request_index;   // The index in request's `entries` array that was resolved via Loki Name Service.
      uint16_t    type;            // The category the Loki Name Service entry belongs to, currently only Session whose value is 0.
      std::string name_hash;       // The hash of the name that the owner purchased via Loki Name Service.
      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
      uint64_t    register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
      std::string txid;            // The txid of who purchases the mapping, null hash if not applicable
      std::string prev_txid;       // The previous txid that purchased the mapping, null hash if not applicable.
    };

    struct response
    {
      std::vector<response_entry> entries;
      std::string status; // Generic RPC error code. "OK" is the success value.
    };
  };
```
